### PR TITLE
Xvba

### DIFF
--- a/lib/ffmpeg/libavcodec/xvba_vc1.c
+++ b/lib/ffmpeg/libavcodec/xvba_vc1.c
@@ -42,6 +42,9 @@ static int start_frame(AVCodecContext *avctx,
 
     render = (struct xvba_render_state *)s->current_picture_ptr->data[0];
     assert(render);
+
+    if (render->picture_descriptor == 0)
+      return -1;
     
     render->num_slices = 0;
     return 0;


### PR DESCRIPTION
Check for null pointer of picture_descriptor. Questions are: 
a )Should it be enough to check it in start_frame
b) Is a check needed in start_frame and end_frame (this patch assumes this in order to be in sync with handling in h264)
