### PR TITLE
Support interlaced output with new WeaveX2 deinterlace mode

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -368,7 +368,8 @@ bool CDecoder::Supports(EINTERLACEMETHOD method)
 
   if (g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv"))
   {
-    if (method == VS_INTERLACEMETHOD_RENDER_BOB)
+    if (method == VS_INTERLACEMETHOD_RENDER_BOB
+     || method == VS_INTERLACEMETHOD_RENDER_WEAVEX2)
       return true;
   }
 
@@ -2147,7 +2148,8 @@ void CMixer::InitCycle()
                                         DVP_FLAG_INTERLACED);
       m_config.useInteropYuv = false;
     }
-    else if (method == VS_INTERLACEMETHOD_RENDER_BOB && m_config.useInteropYuv)
+    else if ((method == VS_INTERLACEMETHOD_RENDER_BOB
+           || method == VS_INTERLACEMETHOD_RENDER_WEAVEX2) && m_config.useInteropYuv)
     {
       m_mixersteps = 1;
       m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_FRAME;


### PR DESCRIPTION
This is a new deinterlace mode that is used to generate interlaced video output. WeaveX2 differs from normal weave by guaranteeing field synchronisation with the interlaced video display. WeaveX2 doubles the frame rate by inserting a frame every other frame. The inserted frame contains the second field of the previous frame weaved with the first field from the next frame.
