### PR TITLE
general: build fix for gcc 4.7 to help the arch guys still using eden

### DIFF
--- a/xbmc/threads/platform/pthreads/ThreadImpl.h
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <pthread.h>
+#include <unistd.h>
 
 struct threadOpaque
 {


### PR DESCRIPTION
taken of xbmc-11.0.3-902.02-xvba_support-gcc-4.7.patch by openelec
