### PR TITLE
Disable vdpau YUV Interop and Studio Level

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -365,7 +365,7 @@ bool CDecoder::Supports(EINTERLACEMETHOD method)
   || method == VS_INTERLACEMETHOD_AUTO)
     return true;
 
-  if (g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv"))
+  if (0) //g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv"))
   {
     if (method == VS_INTERLACEMETHOD_RENDER_BOB)
       return true;
@@ -1698,7 +1698,7 @@ void CMixer::SetColor()
     //vdp_st = vdp_generate_csc_matrix(&m_Procamp, VDP_COLOR_STANDARD_ITUR_BT_601, &m_CSCMatrix);
 
   VdpVideoMixerAttribute attributes[] = { VDP_VIDEO_MIXER_ATTRIBUTE_CSC_MATRIX };
-  if (g_guiSettings.GetBool("videoplayer.vdpaustudiolevel"))
+  if (0) //g_guiSettings.GetBool("videoplayer.vdpaustudiolevel"))
   {
     float studioCSC[3][4];
     GenerateStudioCSCMatrix(colorStandard, studioCSC);
@@ -1847,7 +1847,7 @@ void CMixer::SetDeinterlacing()
 
   SetDeintSkipChroma();
 
-  m_config.useInteropYuv = g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv");
+  m_config.useInteropYuv = false; //g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv");
 }
 
 void CMixer::SetDeintSkipChroma()
@@ -2039,7 +2039,7 @@ void CMixer::Init()
   m_vdpError = false;
 
   m_config.upscale = g_advancedSettings.m_videoVDPAUScaling;
-  m_config.useInteropYuv = g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv");
+  m_config.useInteropYuv = false; //g_guiSettings.GetBool("videoplayer.usevdpauinteropyuv");
 
   CreateVdpauMixer();
 }
@@ -3218,7 +3218,7 @@ bool COutput::GLInit()
   {
     m_config.usePixmaps = true;
     g_guiSettings.SetBool("videoplayer.usevdpauinterop",false);
-    g_guiSettings.SetBool("videoplayer.usevdpauinteropyuv",false);
+//    g_guiSettings.SetBool("videoplayer.usevdpauinteropyuv",false);
   }
   if (!glXBindTexImageEXT)
     glXBindTexImageEXT    = (PFNGLXBINDTEXIMAGEEXTPROC)glXGetProcAddress((GLubyte *) "glXBindTexImageEXT");

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -692,7 +692,7 @@ void CGUISettings::Initialize()
 #ifdef HAVE_LIBVDPAU
   AddBool(vp, "videoplayer.usevdpau", 13425, true);
   AddBool(vp, "videoplayer.usevdpauinterop", 13435, true);
-  AddBool(vp, "videoplayer.usevdpauinteropyuv", 13436, false);
+  // AddBool(vp, "videoplayer.usevdpauinteropyuv", 13436, false);
 #endif
 #ifdef HAVE_LIBVA
   AddBool(vp, "videoplayer.usevaapi", 13426, true);
@@ -774,7 +774,7 @@ void CGUISettings::Initialize()
   AddSeparator(vp, "videoplayer.sep1.5");
 #ifdef HAVE_LIBVDPAU
   AddBool(NULL, "videoplayer.vdpauUpscalingLevel", 13121, false);
-  AddBool(vp, "videoplayer.vdpaustudiolevel", 13122, false);
+//  AddBool(vp, "videoplayer.vdpaustudiolevel", 13122, false);
 #endif
 #endif
   AddSeparator(vp, "videoplayer.sep5");


### PR DESCRIPTION
Conflicts: xbmc/settings/GUISettings.cpp solved by adapting to new vdpauinteropyuv 13436 ID

This is a cherry-pick from oe20 patch and conflicts solved as the ID for interopyouv has changed to 134336
