### PR TITLE
x11: support for multiple x screens

### DIFF
--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -92,7 +92,7 @@ bool CXRandR::Query(bool force, int screennum)
   pclose(file);
 
   TiXmlElement *pRootElement = xmlDoc.RootElement();
-  if (strcasecmp(pRootElement->Value(), "screen") != screennum)
+  if (atoi(pRootElement->Attribute("id")) != screennum)
   {
     // TODO ERROR
     return false;


### PR DESCRIPTION
This is a small fix to get XBMC working with multiple X screens. Without it, XBMC only starts on screen 0.0
