### PR TITLE
dvdplayer: Allow multithread decoding for hi10p content by default

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -154,6 +154,7 @@ CDVDVideoCodecFFmpeg::CDVDVideoCodecFFmpeg() : CDVDVideoCodec()
   m_iScreenHeight = 0;
   m_iOrientation = 0;
   m_bSoftware = false;
+  m_isHi10p = false;
   m_pHardware = NULL;
   m_iLastKeyframe = 0;
   m_dts = DVD_NOPTS_VALUE;
@@ -204,7 +205,10 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       case FF_PROFILE_H264_HIGH_444_PREDICTIVE:
       case FF_PROFILE_H264_HIGH_444_INTRA:
       case FF_PROFILE_H264_CAVLC_444:
+      // this is needed to not open the decoders
       m_bSoftware = true;
+      // this we need to enable multithreading for hi10p via advancedsettings
+      m_isHi10p = true;
       break;
     }
   }
@@ -277,8 +281,18 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_pCodecContext->codec_tag = hints.codec_tag;
   /* Only allow slice threading, since frame threading is more
    * sensitive to changes in frame sizes, and it causes crashes
-   * during HW accell */
-  m_pCodecContext->thread_type = FF_THREAD_SLICE;
+   * during HW accell - so we unset it in this case.
+   *
+   * When we detect Hi10p and user did not disable hi10pmultithreading
+   * via advancedsettings.xml we keep the ffmpeg default thread type.
+   * */
+  if(m_isHi10p && !g_advancedSettings.m_videoDisableHi10pMultithreading)
+  {
+    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for Hi10p: %d",
+                        m_pCodecContext->thread_type);
+  }
+  else
+    m_pCodecContext->thread_type = FF_THREAD_SLICE;
 
 #if defined(TARGET_DARWIN_IOS)
   // ffmpeg with enabled neon will crash and burn if this is enabled

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -116,6 +116,7 @@ protected:
 
   std::string m_name;
   bool              m_bSoftware;
+  bool  m_isHi10p;
   IHardwareDecoder *m_pHardware;
   int m_iLastKeyframe;
   double m_dts;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -116,6 +116,7 @@ void CAdvancedSettings::Initialize()
   m_DXVANoDeintProcForProgressive = false;
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
+  m_videoDisableHi10pMultithreading = false;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -502,6 +503,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vdpau",m_videoAllowMpeg4VDPAU);
+    XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -168,6 +168,7 @@ class CAdvancedSettings
     bool m_DXVAForceProcessorRenderer;
     bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
+    bool m_videoDisableHi10pMultithreading;
 
     CStdString m_videoDefaultPlayer;
     CStdString m_videoDefaultDVDPlayer;


### PR DESCRIPTION
This allows decoding of some hi10p material on e.g. AMD Fusion with
both cores at the max. This introduces a new advancedsetting named
disablehi10pmultithreading to disable hi10p decoded multithreaded.

Same as the other one - but backport to frodo. So we have this in, when we park it for eternity.
