### PR TITLE
ffmpeg: vc1 mapping

### DIFF
--- a/lib/ffmpeg/libavcodec/xvba_vc1.c
+++ b/lib/ffmpeg/libavcodec/xvba_vc1.c
@@ -99,7 +99,7 @@ static int end_frame(AVCodecContext *avctx)
     pic_descriptor->sps_info.vc1.psf                        = v->psf;
     // what about if it is a frame (page 31)
     // looked at xvba-driver
-    pic_descriptor->sps_info.vc1.second_field               = !s->first_field;
+    pic_descriptor->sps_info.vc1.second_field               = v->second_field;
     pic_descriptor->sps_info.vc1.xvba_vc1_sps_reserved      = 0;
     
     // VC-1 explicit parameters see page 30 of sdk


### PR DESCRIPTION
ffmpeg now provides second_field itself. This should make interlaced VC1 working. Thanks to @JeroenDeKleijn.

Btw. my VC1 sample seems to be interlaced differently, so I could only test other VC1 files to not cause regressions.
