### PR TITLE
XVBA: Revisit second field again

### DIFF
--- a/lib/ffmpeg/libavcodec/xvba_vc1.c
+++ b/lib/ffmpeg/libavcodec/xvba_vc1.c
@@ -99,7 +99,7 @@ static int end_frame(AVCodecContext *avctx)
     pic_descriptor->sps_info.vc1.psf                        = v->psf;
     // what about if it is a frame (page 31)
     // looked at xvba-driver
-    pic_descriptor->sps_info.vc1.second_field               = v->second_field;
+    pic_descriptor->sps_info.vc1.second_field               = v->interlace && v->second_field && (v->fcm == ILACE_FIELD);
     pic_descriptor->sps_info.vc1.xvba_vc1_sps_reserved      = 0;
     
     // VC-1 explicit parameters see page 30 of sdk


### PR DESCRIPTION
Only set this field, when we are interlaced and when we have interlaced field.

No regressions with the standard VC-1 testfiles. But something is still missing for a specific kind of testfiles.
