### PR TITLE
XVBA: Limit size again

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/XVBA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/XVBA.cpp
@@ -340,10 +340,12 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat fmt, unsigned 
   // it seems that xvba does not support anything > 2k
   // return false, for files that are larger
   // if you are unlucky, this would kill your decoder
-  // we limit to 2048x1536(+8) now - as this was tested working
+  // we limit to 2048x1152 now - as this was reported by ckoenig the UVD OSS 
+  // engineer to be the maximum technically possible for all hardware with UVD.
+  // Some chips can do a bit more, but we use the safe default.
   int surfaceWidth = (avctx->coded_width+15) & ~15;
   int surfaceHeight = (avctx->coded_height+15) & ~15;
-  if(surfaceHeight > 1544 || surfaceWidth > 2048)
+  if(surfaceHeight > 1152 || surfaceWidth > 2048)
   {
     CLog::Log(LOGERROR, "Surface too large, decoder skipped: surfaceWidth %u, surfaceHeight %u",
                         surfaceWidth, surfaceHeight);


### PR DESCRIPTION
I talked to Christian König on IRC. He is the UVD OSS engineere of AMD and he told me that 1536 is not safe for all chips with UVD. Therefore let's shrink it.

I don't see a point making an advanced setting, as it should be the job of the SDK to exit gracefully or give us the supported height / width in time, when this happens.
