### PR TITLE
AE: Don't end up unitialized 

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1156,6 +1156,10 @@ bool CAESinkALSA::SoftResume()
     {
       if (!snd_config)
         snd_config_update();
+
+    // Initialize what we had before again, SoftAE might keep it
+    // but ignore ret value to give the chance to do reopening
+    Initialize(m_initFormat, m_initDevice);
     }
    // make sure that OpenInternalSink is done again
    return false;


### PR DESCRIPTION
Squash to: e4378bde91745b73a2b493a0043c3dee1343557e

Initial Problem:

User watches video with AC3 sound, presses pause, waits 10 seconds, presses stop. When pressing next menu sound, SoftResume is called, that succesfully calls Initialize (for AC3). All menu sounds are played through AC3 - which sounds not so nice, cause reinit returns false.

First fix, did not call Initialize at all - therefore AE decided to keep the sink, but this was not correctly setup when playing next song.

Now I call Initialize, but return false. So if AE wants to keep the sink - all fine. If it needs reinitialize also fine, cause of the return of false.
