### PR TITLE
AE: Give Sinks the possibility to be used in a blocking way

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -240,6 +240,11 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t *data, unsigned int frames, b
         break;
     }
   }
+  // AddPackets runs under a non-idled AE thread we must block or sleep.
+  // Trying to calc the optimal sleep is tricky so just a minimal sleep.
+  if(blocking)
+    Sleep(10);
+
   return hasAudio ? write_frames:frames;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -386,10 +386,15 @@ unsigned int CAESinkDirectSound::AddPackets(uint8_t *data, unsigned int frames, 
 
   while (GetSpace() < total)
   {
-    if (m_isDirtyDS)
+    if(m_isDirtyDS)
       return INT_MAX;
     else
-      return 0;
+    {
+      if(blocking)
+        Sleep(total * 1000 / m_AvgBytesPerSec);
+      else
+        return 0;
+    }
   }
 
   while (len)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -420,7 +420,7 @@ unsigned int CAESinkOSS::AddPackets(uint8_t *data, unsigned int frames, bool has
   int wrote = write(m_fd, data, size);
   if (wrote < 0)
   {
-    if(errno == EAGAIN || errno == EWOULDBLOCK)
+    if(!blocking && (errno == EAGAIN || errno == EWOULDBLOCK))
       return 0;
 
     CLog::Log(LOGERROR, "CAESinkOSS::AddPackets - Failed to write");

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -488,10 +488,32 @@ unsigned int CAESinkWASAPI::AddPackets(uint8_t *data, unsigned int frames, bool 
 #endif
 
   /* Wait for Audio Driver to tell us it's got a buffer available */
-  DWORD eventAudioCallback = WaitForSingleObject(m_needDataEvent, 0);
+  if(!blocking)
+    DWORD eventAudioCallback = WaitForSingleObject(m_needDataEvent, 0);
+  else
+    DWORD eventAudioCallback = WaitForSingleObject(m_needDataEvent, 1100);
 
-  if (eventAudioCallback != WAIT_OBJECT_0)
-    return 0;
+  if (!blocking)
+  {
+    if(eventAudioCallback != WAIT_OBJECT_0)
+	  return 0;
+  }
+  else
+  {
+    if(eventAudioCallback != WAIT_OBJECT_0 || !&buf)
+    {
+      /* Event handle timed out - flag sink as dirty for re-initializing */
+      CLog::Log(LOGERROR, __FUNCTION__": Endpoint Buffer timed out");
+      if (g_advancedSettings.m_streamSilence)
+      {
+        m_isDirty = true; //flag new device or re-init needed
+        Deinitialize();
+        m_running = false;
+        return INT_MAX;
+      }
+    }
+  }
+
 
   if (!m_running)
     return 0;


### PR DESCRIPTION
This builds back the Sinks to the state where they were before c2493d5bf6bc2be2fb45f563affdd214bf9862fb I am not sure if it is enough for OSS Sink or if we need something additional there like:

```
diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
index ab13671..9d85f0a 100644
--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -321,7 +321,8 @@ bool CAESinkOSS::Initialize(AEAudioFormat &format, std::string &device)
     return false;
   }

-  if (fcntl(m_fd, F_SETFL,  fcntl(m_fd, F_GETFL, 0) | O_NONBLOCK) == -1)
+  // RAW formats don't play nice with non blocking sinks
+  if (!AE_IS_RAW(format.m_dataFormat) && (fcntl(m_fd, F_SETFL,  fcntl(m_fd, F_GETFL, 0) | O_NONBLOCK) == -1))
   {
     close(m_fd);
     CLog::Log(LOGERROR, "CAESinkOSS::Initialize - Failed to set non blocking writes");
```

I pinged @fneufneuf in irc - let's see.

Another point is: I cannot test :-)
