### PR TITLE
ActiveAE: Fix compilation on non __SSE__ platforms

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1353,8 +1353,9 @@ bool CActiveAE::RunStages()
 #ifdef __SSE__
                 CAEUtil::SSEMulArray((float*)out->pkt->data[j], volume, nb_floats);
 #else
+                float* fbuffer = (float*) out->pkt->data[j];
                 for (int k = 0; k < nb_floats; ++k)
-                  *dst++ *= volume;
+                  *fbuffer++ *= volume;
 #endif
               }
             }
@@ -1570,7 +1571,7 @@ void CActiveAE::Deamplify(CSoundPacket &dstSample)
       CAEUtil::SSEMulArray(buffer, m_volume, nb_floats);
 #else
       float *fbuffer = buffer;
-      for (unsigned int i = 0; i < samples; i++)
+      for (unsigned int i = 0; i < nb_floats; i++)
         *fbuffer++ *= m_volume;
 #endif
     }


### PR DESCRIPTION
That - hopefully - works. @wsnipex is currently building on launchpad. I will report back, if it worked out :-)
