### PR TITLE
ActiveAE: Make ActiveAE the default engine 

### DIFF
--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -97,7 +97,7 @@ bool CAEFactory::LoadEngine()
     loaded = CAEFactory::LoadEngine(AE_ENGINE_COREAUDIO);
 #else
   if (!loaded)
-    loaded = CAEFactory::LoadEngine(AE_ENGINE_SOFT);
+    loaded = CAEFactory::LoadEngine(AE_ENGINE_ACTIVE);
 #endif
 
   return loaded;


### PR DESCRIPTION
We want it to be tested with latest xbmc-xvba-testing
