### PR TITLE
ActiveAE: Remove special case - after 37b8fb75af29c071a47d1557fe7dfff0b0812dc4

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -826,14 +826,7 @@ void CActiveAESink::GenerateNoise()
     noise[i] = (float) sqrt( -2.0f * log( R1 )) * cos( 2.0f * PI * R2 ) * 0.00001;
   }
 
-  if (m_sinkFormat.m_dataFormat != AE_FMT_FLOAT)
-  {
-    CAEConvert::AEConvertFrFn convertFn = CAEConvert::FrFloat(m_sinkFormat.m_dataFormat);
-    convertFn(noise, nb_floats, m_sampleOfNoise.pkt->data[0]);
-  }
-  else
-  {
-    memcpy(m_sampleOfNoise.pkt->data[0], noise, nb_floats*sizeof(float));
-  }
+  CAEConvert::AEConvertFrFn convertFn = CAEConvert::FrFloat(m_sinkFormat.m_dataFormat);
+  convertFn(noise, nb_floats, m_sampleOfNoise.pkt->data[0]);
   delete [] noise;
 }


### PR DESCRIPTION
Not needed anymore
