### PR TITLE
ActiveAE: Only transcode to ac3 when input has more than two channels

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1093,7 +1093,7 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat &format, AudioSettings &sett
     }
   }
   // transcode
-  else if (m_settings.mode != AUDIO_ANALOG && settings.ac3passthrough && !settings.multichannellpcm && !m_streams.empty())
+  else if (m_settings.mode != AUDIO_ANALOG && settings.ac3passthrough && !settings.multichannellpcm && !m_streams.empty() && format.m_channelLayout.Count() > 2)
   {
     format.m_dataFormat = AE_FMT_AC3;
     format.m_sampleRate = 48000;


### PR DESCRIPTION
ANALOG is a bit of a problem.

If you have set HDMI and your normal output device, you still want mp3 and other stuff played as PCM and not as AC3, therefore also check to have more than 2 channels before choosing AC3 as default output.

@FernetMenta: The fix from yesterday is still valid I think, as i see no need in converting e.g. 2 channel {DTS, DTS-HD, TrueHD, etc.} to AC3. as it can played as 2.0 pcm easily.
