### PR TITLE
ActiveAESink: reduce time between streaming of Noise

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -432,7 +432,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           }
           else if(m_extCycleCounter <= 0)
           {
-            m_extCycleCounter = 30;
+            m_extCycleCounter = 20;
             m_state = S_TOP_CONFIGURED_SILENCE;
           }
           m_extTimeout = 0;


### PR DESCRIPTION
Some AVRs PCMs started to blink PCMs e.g. on / off / on / off.

@newphreak should also test this.
