### PR TITLE
Viz crash fix

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1504,7 +1504,7 @@ bool CActiveAE::RunStages()
         // viz
         {
           CSingleLock lock(m_vizLock);
-          if (m_audioCallback)
+          if (m_audioCallback && m_vizBuffers)
           {
             if (!m_vizInitialized)
             {


### PR DESCRIPTION
These commits fix a reproducible crash when stopping playback from viz as screensaver window.  It's very racy as I could only manage to get it to crash consistently on my ION HTPC.  The first commit seems to be enough, but I suspect the risk is still there without the locking introduced in the second commit.  @fritsch had some reservations about adding locking here, so the second commit is an RFC. 
