### PR TITLE
AESinkOSS: Implement Drain()

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -435,7 +435,10 @@ void CAESinkOSS::Drain()
   if (m_fd == -1)
     return;
 
-  // ???
+  if(ioctl(m_fd, SNDCTL_DSP_SYNC, NULL) == -1)
+  {
+    CLog::Log(LOGERROR, "CAESinkOSS::Drain - Draining the Sink failed");
+  }
 }
 
 void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)


### PR DESCRIPTION
Tested by @fneufneu on IRC. Some literature is here: http://www.4front-tech.com/pguide/audio.html

I think using that ioctl as drain is a good idea

```
- Call SNDCTL_DSP_SYNC when you want to wait until all data has been played.
- SNDCTL_DSP_RESET or SNDCTL_DSP_SYNC should be called when the application wants to change sampling parameters (speed, number of channels or number of bits).
```
