### PR TITLE
AESinkOSS: Make sink usable in blocking mode

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
@@ -46,6 +46,7 @@ public:
   static  void         EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 private:
   int m_fd;
+  bool m_blockingNeedsUpdate;
   std::string      m_device;
   AEAudioFormat   m_initFormat;
   AEAudioFormat   m_format;


### PR DESCRIPTION
If the oss sink is in non blocking mode ActiveAE won't work at all on BSD. Therefore set the mode when first package arrives.
