### PR TITLE
AESinkOSS: Missed one reusal of format.m_dataFormat 

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -262,7 +262,7 @@ bool CAESinkOSS::Initialize(AEAudioFormat &format, std::string &device)
 
 #if defined(TARGET_FREEBSD)
   /* fix hdmi 8 channels order */
-  if (!AE_IS_RAW(format.m_dataFormat) && 8 == oss_ch)
+  if ((oss_fmt != AFMT_AC3) && 8 == oss_ch)
   {
     unsigned long long order = 0x0000000087346521ULL;
 


### PR DESCRIPTION
after 4c536e960dfa5610bd62968feff1eebaada17c6d

Sorry - I did not see that AE_IS_RAW is asked again later. Thanks @fneufneu for pointing out. This one could be squashed later.
