### PR TITLE
ActiveAE: Fix refcounting with viz

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1596,6 +1596,7 @@ bool CActiveAE::RunStages()
       }
 
       // process output buffer, gui sounds, encode, viz
+      CSampleBuffer *viz = NULL;
       if (out)
       {
         // mix gui sounds
@@ -1603,20 +1604,16 @@ bool CActiveAE::RunStages()
         if (!m_sinkHasVolume)
           Deamplify(*(out->pkt));
 
-        // encode
+        // encode and backup out buffer for viz
+        viz = out;
         if (m_mode == MODE_TRANSCODE && m_encoder)
         {
           CSampleBuffer *buf = m_encoderBuffers->GetFreeBuffer();
           m_encoder->Encode(out->pkt->data[0], out->pkt->planes*out->pkt->linesize,
                             buf->pkt->data[0], buf->pkt->planes*buf->pkt->linesize);
           buf->pkt->nb_samples = buf->pkt->max_nb_samples;
-          out->Return();
           out = buf;
         }
-
-        // update stats
-        m_stats.AddSamples(out->pkt->nb_samples, m_streams);
-        m_sinkBuffers->m_inputSamples.push_back(out);
 
         busy = true;
       }
@@ -1632,13 +1629,13 @@ bool CActiveAE::RunStages()
             m_vizInitialized = true;
           }
 
-          // if viz has no free buffer, it won't return current buffer "out"
+          // if viz has no free buffer, it won't return current buffer "viz"
           if (!m_vizBuffers->m_freeSamples.empty())
           {
-            if (out)
+            if (viz)
             {
-              out->Acquire();
-              m_vizBuffers->m_inputSamples.push_back(out);
+              viz->Acquire();
+              m_vizBuffers->m_inputSamples.push_back(viz);
             }
           }
           else
@@ -1668,6 +1665,14 @@ bool CActiveAE::RunStages()
         }
         else if (m_vizBuffers)
           m_vizBuffers->Flush();
+      }
+      // update stats
+      if(out)
+      {
+        m_stats.AddSamples(out->pkt->nb_samples, m_streams);
+        m_sinkBuffers->m_inputSamples.push_back(out);
+        if(viz && (viz != out))
+          viz->Return();
       }
     }
     // pass through


### PR DESCRIPTION
If we transcode and display viz (music upmixing via ac3) viz needs the original out. Decrement the refs after usage.
