### PR TITLE
fix crystalHD ffmpeg include path

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
@@ -41,7 +41,7 @@ extern "C" {
 }
 #include "utils/TimeUtils.h"
 #include "windowing/WindowingFactory.h"
-#include "lib/ffmpeg.h"
+#include "cores/FFmpeg.h"
 
 namespace BCM
 {


### PR DESCRIPTION
thanks for fixing up the callbacks!
this should be squashed somewhere.
