### PR TITLE
remove ffmpeg dlls from generated headers

### DIFF
--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -37,13 +37,8 @@ extern "C" {
 #pragma warning(disable:4244)
 #endif
   
-#if (defined USE_EXTERNAL_FFMPEG)
-  #include <libavutil/avutil.h>
-  #include <libpostproc/postprocess.h>
-#else
-  #include "libavutil/avutil.h"
-  #include "libpostproc/postprocess.h"
-#endif
+#include <libavutil/avutil.h>
+#include <libpostproc/postprocess.h>
 }
 
 #include "utils/CPUInfo.h"
@@ -78,9 +73,6 @@ public:
   virtual void pp_free_context(pp_context *ppContext)=0;
 };
 
-#if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
-
-// We call directly.
 class DllPostProc : public DllDynamic, DllPostProcInterface
 {
 public:
@@ -103,25 +95,3 @@ public:
   virtual void Unload() {}
 };
 
-#else
-class DllPostProc : public DllDynamic, DllPostProcInterface
-{
-  DECLARE_DLL_WRAPPER(DllPostProc, DLL_PATH_LIBPOSTPROC)
-  DEFINE_METHOD11(void, pp_postprocess, (uint8_t* p1[3], int p2[3], uint8_t * p3[3], int p4[3],
-                      int p5, int p6, QP_STORE_T *p7,  int p8,
-                      pp_mode *p9, pp_context *p10, int p11))
-  DEFINE_METHOD2(pp_mode*, pp_get_mode_by_name_and_quality, (char *p1, int p2))
-  DEFINE_METHOD1(void, pp_free_mode, (pp_mode *p1))
-  DEFINE_METHOD3(pp_context*, pp_get_context, (int p1, int p2, int p3))
-  DEFINE_METHOD1(void, pp_free_context, (pp_context *p1))
-
-  BEGIN_METHOD_RESOLVE()
-    RESOLVE_METHOD(pp_postprocess)
-    RESOLVE_METHOD(pp_get_mode_by_name_and_quality)
-    RESOLVE_METHOD(pp_free_mode)
-    RESOLVE_METHOD(pp_get_context)
-    RESOLVE_METHOD(pp_free_context)
-  END_METHOD_RESOLVE()
-};
-
-#endif

--- a/xbmc/DllPaths_generated.h.in
+++ b/xbmc/DllPaths_generated.h.in
@@ -72,15 +72,6 @@
 #define DLL_PATH_LIBMPEG2      "@MPEG2_SONAME@"
 #define DLL_PATH_LIBMAD        "@MAD_SONAME@"
 
-/* ffmpeg */
-#define DLL_PATH_LIBAVCODEC    "special://xbmcbin/system/players/dvdplayer/avcodec-54-@ARCH@.so"
-#define DLL_PATH_LIBAVFORMAT   "special://xbmcbin/system/players/dvdplayer/avformat-54-@ARCH@.so"
-#define DLL_PATH_LIBAVUTIL     "special://xbmcbin/system/players/dvdplayer/avutil-52-@ARCH@.so"
-#define DLL_PATH_LIBPOSTPROC   "special://xbmcbin/system/players/dvdplayer/postproc-52-@ARCH@.so"
-#define DLL_PATH_LIBSWSCALE    "special://xbmcbin/system/players/dvdplayer/swscale-2-@ARCH@.so"
-#define DLL_PATH_LIBAVFILTER   "special://xbmcbin/system/players/dvdplayer/avfilter-3-@ARCH@.so"
-#define DLL_PATH_LIBSWRESAMPLE "special://xbmcbin/system/players/dvdplayer/swresample-0-@ARCH@.so"
-
 /* cdrip */
 #define DLL_PATH_LAME_ENC      "@LAMEENC_SONAME@"
 #define DLL_PATH_OGG           "@OGG_SONAME@"

--- a/xbmc/DllPaths_generated_android.h.in
+++ b/xbmc/DllPaths_generated_android.h.in
@@ -75,15 +75,6 @@
 #define DLL_PATH_LIBMAD        "@MAD_SONAME@"
 #define DLL_PATH_LIBSTAGEFRIGHTICS    "libXBMCvcodec_stagefrightICS-@ARCH@.so"
 
-/* ffmpeg */
-#define DLL_PATH_LIBAVCODEC    "libavcodec-54-@ARCH@.so"
-#define DLL_PATH_LIBAVFORMAT   "libavformat-54-@ARCH@.so"
-#define DLL_PATH_LIBAVUTIL     "libavutil-52-@ARCH@.so"
-#define DLL_PATH_LIBPOSTPROC   "libpostproc-52-@ARCH@.so"
-#define DLL_PATH_LIBSWSCALE    "libswscale-2-@ARCH@.so"
-#define DLL_PATH_LIBAVFILTER   "libavfilter-3-@ARCH@.so"
-#define DLL_PATH_LIBSWRESAMPLE "libswresample-0-@ARCH@.so"
-
 /* cdrip */
 #define DLL_PATH_LAME_ENC      "@LAMEENC_SONAME@"
 #define DLL_PATH_OGG           "@OGG_SONAME@"


### PR DESCRIPTION
not removing win32 as this might still be needed?
