### PR TITLE
Introduce SWCodec

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -163,7 +163,7 @@ CDVDVideoCodecFFmpeg::CDVDVideoCodecFFmpeg() : CDVDVideoCodec()
   m_iScreenHeight = 0;
   m_iOrientation = 0;
   m_bSoftware = false;
-  m_isHi10p = false;
+  m_isSWCodec = false;
   m_pHardware = NULL;
   m_iLastKeyframe = 0;
   m_dts = DVD_NOPTS_VALUE;
@@ -209,10 +209,15 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       // this is needed to not open the decoders
       m_bSoftware = true;
       // this we need to enable multithreading for hi10p via advancedsettings
-      m_isHi10p = true;
+      m_isSWCodec = true;
       break;
     }
   }
+  #ifdef AV_CODEC_ID_HEVC
+  else if (hints.codec == AV_CODEC_ID_HEVC)
+    m_isSWCodec = true;
+  #endif
+
 
   if(pCodec == NULL)
     pCodec = avcodec_find_decoder(hints.codec);
@@ -238,12 +243,12 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
    * sensitive to changes in frame sizes, and it causes crashes
    * during HW accell - so we unset it in this case.
    *
-   * When we detect Hi10p and user did not disable hi10pmultithreading
+   * When we detect a pure SW codec and user did not disable SWmultithreading
    * via advancedsettings.xml we keep the ffmpeg default thread type.
    * */
-  if(m_isHi10p && !g_advancedSettings.m_videoDisableHi10pMultithreading)
+  if(m_isSWCodec && !g_advancedSettings.m_videoDisableSWMultithreading)
   {
-    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for Hi10p: %d",
+    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for swcodec: %d",
                         m_pCodecContext->thread_type);
   }
   else if (CSettings::Get().GetBool("videoplayer.useframemtdec"))

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -121,7 +121,7 @@ protected:
 
   std::string m_name;
   bool              m_bSoftware;
-  bool  m_isHi10p;
+  bool  m_isSWCodec;
   IHardwareDecoder *m_pHardware;
   int m_iLastKeyframe;
   double m_dts;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -184,7 +184,7 @@ void CAdvancedSettings::Initialize()
   m_stagefrightConfig.useInputDTS = false;
 
   m_videoDefaultLatency = 0.0;
-  m_videoDisableHi10pMultithreading = false;
+  m_videoDisableSWMultithreading = false;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -600,7 +600,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vdpau",m_videoAllowMpeg4VDPAU);
-    XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
+    XMLUtils::GetBoolean(pElement,"disableswmultithreading",m_videoDisableSWMultithreading);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -196,7 +196,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
     int  m_videoBusyDialogDelay_ms;
-    bool m_videoDisableHi10pMultithreading;
+    bool m_videoDisableSWMultithreading;
     StagefrightConfig m_stagefrightConfig;
 
     CStdString m_videoDefaultPlayer;


### PR DESCRIPTION
These are codecs that don't have any GPU acceleration (yet) for example HEVC or Hi10p. It keeps default ffmpeg threading policy.

Why?
(concerning ffmpeg I consider your tree as my upstream)
