### PR TITLE
VAAPI: Use SWFilter only for max 1920 x 1088 surfaces

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -404,7 +404,10 @@ bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int su
   if (!EnsureContext(avctx))
     return false;
 
-  CheckUseFilter();
+  if (avctx->width <= 1920 && avctx->height <= 1088)
+    CheckUseFilter();
+  else
+    m_use_filter = false;
 
   m_hwaccel->display     = m_display->get();
 


### PR DESCRIPTION
I am not 100% sure with the vaDestroyImage - cause normally, there is nothing to destroy when the first deriveImage did not work out.

Works as intended.
