### PR TITLE
VAAPI: Show swfilter setting when on advanced level

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -521,7 +521,7 @@
           <dependencies>
             <dependency type="visible" setting="videoplayer.usevaapi" operator="is">true</dependency>
           </dependencies>
-          <level>3</level>
+          <level>2</level>
           <default>false</default>
           <control type="toggle" />
         </setting>


### PR DESCRIPTION
This also happened after rebase. User asked on IRC that the setting was gone. I think it's good to have it on level 2.
