### PR TITLE
HEVC: Fix multithreading - brown paper bag for me

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -212,11 +212,8 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       break;
     }
   }
-  #ifdef AV_CODEC_ID_HEVC
   else if (hints.codec == AV_CODEC_ID_HEVC)
     m_isSWCodec = true;
-  #endif
-
 
   if(pCodec == NULL)
     pCodec = avcodec_find_decoder(hints.codec);


### PR DESCRIPTION
AV_CODEC_ID_HEV is an enum no define - so the SWcodec was never set and HEVC was only single threaded.
