### PR TITLE
AESinkPULSE: Return false if device could not be found

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -533,6 +533,7 @@ bool CAESinkPULSE::Initialize(AEAudioFormat &format, std::string &device)
     CLog::Log(LOGERROR, "PulseAudio: Sink %s not found", device.c_str());
     pa_threaded_mainloop_unlock(m_MainLoop);
     Deinitialize();
+    return false;
   }
 
   // Pulse can resample everything between 1 hz and 192000 hz


### PR DESCRIPTION
That one was missing here. Deinitializing everything and continueing was not really smart.

This could happen, when you remove an USB device or hdmi audio device (which is stil read from guisettings.xml on start) - so in order that AE reopens us, this needs to return false
