### PR TITLE
[linux] refine ffmpeg version check and logging

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1714,6 +1714,10 @@ FFMPEG_LIBNAMES="libavcodec >= 55.39.101
                  libswscale >= 2.5.101
                  libswresample >= 0.17.104"
 
+ffmpeg_build="${abs_top_srcdir}/tools/depends/target/ffmpeg"
+FFMPEG_VER_SHA=$(grep "VERSION=" ${ffmpeg_build}/FFMPEG-VERSION | sed 's/VERSION=//g')
+AC_DEFINE_UNQUOTED([FFMPEG_VER_SHA], ["$FFMPEG_VER_SHA"], [FFmpeg version hash])
+
 if test "$with_ffmpeg" = "shared"; then
   # allow linking against shared ffmpeg libs
   # a proper version must be installed, we won't build ffmpeg
@@ -1734,7 +1738,6 @@ if test "${USE_STATIC_FFMPEG}" = "1"; then
   fi
 
   if test "$cross_compiling" != "yes"; then
-    ffmpeg_build="${abs_top_srcdir}/tools/depends/target/ffmpeg"
     if test "$use_debug" != "yes"; then
       FFMPEG_OPTS="-r"
     fi

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -741,9 +741,14 @@ bool CApplication::Create()
   CLog::Log(LOGNOTICE, "Running on Android %d-bit API level %d (%s, %s)", g_sysinfo.GetKernelBitness(), CJNIBuild::SDK_INT, g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
 #elif defined(TARGET_POSIX)
   CLog::Log(LOGNOTICE, "Running on Linux %d-bit (%s, %s)", g_sysinfo.GetKernelBitness(), g_sysinfo.GetLinuxDistro().c_str(), g_sysinfo.GetUnameVersion().c_str());
-  CLog::Log(LOGNOTICE, "Using ffmpeg version %s, static %d", FFMPEG_VERSION, USE_STATIC_FFMPEG);
-  if (!strstr(FFMPEG_VERSION, "xbmc"))
+  CLog::Log(LOGNOTICE, "FFmpeg version: %s, statically linked: %d", FFMPEG_VERSION, USE_STATIC_FFMPEG);
+if (!strstr(FFMPEG_VERSION, FFMPEG_VER_SHA))
+{
+  if (strstr(FFMPEG_VERSION, "xbmc"))
+    CLog::Log(LOGNOTICE, "WARNING: unknown ffmpeg-xbmc version detected");
+  else
     CLog::Log(LOGNOTICE, "WARNING: unsupported ffmpeg version detected");
+}
 #elif defined(TARGET_WINDOWS)
   CLog::Log(LOGNOTICE, "Running on %s", g_sysinfo.GetKernelVersion().c_str());
 #endif


### PR DESCRIPTION
follow up to https://github.com/FernetMenta/xbmc/pull/230
this allows us to check if we are running our current ffmpeg version by checking against the sha from FFMPEG-VERSION
