### PR TITLE
VAAPI: Don't use swfilter for large surfaces - fallback to vaapi render

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -2264,8 +2264,7 @@ void CSkipPostproc::Flush()
 
 bool CSkipPostproc::Compatible(EINTERLACEMETHOD method)
 {
-  if (method == VS_INTERLACEMETHOD_NONE &&
-      CSettings::Get().GetBool("videoplayer.prefervaapirender"))
+  if (method == VS_INTERLACEMETHOD_NONE)
     return true;
 
   return false;


### PR DESCRIPTION
This stops using of sse copy routines for large surfaces. It introduces a fallback to the swrender - cause the statemachine wants a correctly setup m_pp after that method, if we don't care for this AddPicture will segfault.

Open for more input, e.g. better error handling.
