### PR TITLE
VAAPI: Don't init if dimensions are not set

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -464,6 +464,13 @@ bool CDecoder::Open(AVCodecContext* avctx, const enum PixelFormat fmt, unsigned 
   if (!CVAAPIContext::EnsureContext(&m_vaapiConfig.context, this))
     return false;
 
+  if(avctx->coded_width  == 0
+  || avctx->coded_height == 0)
+  {
+    CLog::Log(LOGWARNING,"VAAPI::Open: no width/height available, can't init");
+    return false;
+  }
+
   m_vaapiConfig.vidWidth = avctx->width;
   m_vaapiConfig.vidHeight = avctx->height;
   m_vaapiConfig.outWidth = avctx->width;


### PR DESCRIPTION
This worksaround fancy backends that try to be fast in channel switching and want to init the decoder with wrong height / width.

Btw. I rebased all the way up to xbmc-upstream in my master to probably save you some work after you are back
