### PR TITLE
VideoSync: Add virtual implemented dtor to care for warning

### DIFF
--- a/xbmc/video/videosync/VideoSync.h
+++ b/xbmc/video/videosync/VideoSync.h
@@ -24,6 +24,7 @@ typedef void (*PUPDATECLOCK)(int NrVBlanks, uint64_t time);
 class CVideoSync
 {
 public:
+  virtual ~CVideoSync() {};
   virtual bool Setup(PUPDATECLOCK func) = 0;
   virtual void Run(volatile bool& stop) = 0;
   virtual void Cleanup() = 0;


### PR DESCRIPTION
This fixes compile warning.
