### PR TITLE
Minor fixes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -1253,7 +1253,7 @@ bool CVaapiRenderPicture::GLMapSurface()
 
       attrib = attribs;
       *attrib++ = EGL_LINUX_DRM_FOURCC_EXT;
-      *attrib++ = fourcc_code('G', 'R', '1', '6');
+      *attrib++ = fourcc_code('G', 'R', '8', '8');
       *attrib++ = EGL_WIDTH;
       *attrib++ = (glInterop.vaImage.width + 1) >> 1;
       *attrib++ = EGL_HEIGHT;

--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -164,7 +164,7 @@
 #if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined(__mips__) // should this be powerpc64 only?
 #define __stdcall
 #else /* !__x86_64__ */
-#define __stdcall   __attribute__((__stdcall__))
+#define __stdcall
 #endif /* __x86_64__ */
 #define __cdecl
 #define WINBASEAPI


### PR DESCRIPTION
fourcc has changed after @chadversary prd those to upstream, see: https://github.com/chadversary/mesa/commit/12dcbfff06bd3b4a1e51c25ede5351bad95ab88e

Second hunk: EGL currently does not build on i386 as it seems the system_gl.h is included too late - this is a lazy workaround, input is needed.