### PR TITLE
AdjustRefreshrate: Allow switching to a higher resolution with best match

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -232,10 +232,10 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
   {
     const RESOLUTION_INFO info = g_graphicsContext.GetResInfo((RESOLUTION)i);
 
-    //discard resolutions that are not the same width and height (and interlaced/3D flags)
+    //discard lower resolutions (and interlaced/3D flags)
     //or have a too low refreshrate
-    if (info.iScreenWidth  != curr.iScreenWidth
-    ||  info.iScreenHeight != curr.iScreenHeight
+    if (info.iScreenWidth  < curr.iScreenWidth
+    ||  info.iScreenHeight < curr.iScreenHeight
     ||  info.iScreen       != curr.iScreen
     ||  (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)
     ||  info.fRefreshRate < (fRefreshRate * multiplier / 1.001) - 0.001)
@@ -254,6 +254,14 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
         current = (RESOLUTION)i;
         curr = info;
       }
+      // Prefer highest resolution with best matching refreshrate
+      else if ((diff == last_diff)
+      && (info.iScreenWidth > curr.iScreenWidth)
+      && (info.iScreenHeight > curr.iScreenHeight))
+      {
+        current = (RESOLUTION)i;
+        curr    = info;
+      }
     }
     else
     {
@@ -267,6 +275,14 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
         current = (RESOLUTION)i;
         curr    = info;
       }
+      // Prefer highest resolution with best matching refreshrate
+      else if ((i_weight == c_weight)
+      && (info.iScreenWidth > curr.iScreenWidth)
+      && (info.iScreenHeight > curr.iScreenHeight))
+      {
+        current = (RESOLUTION)i;
+        curr    = info;
+      }
     }
   }
 
@@ -276,6 +292,7 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
   else
     weight = RefreshWeight(curr.fRefreshRate, fRefreshRate * multiplier);
 
+  CLog::Log(LOGDEBUG, "Adjust Refreshrate found mode: %s", curr.strMode.c_str());
   return current;
 }
 


### PR DESCRIPTION
This allows users to run their GUI in e.g. 1080p50 and we will automatically switch to a higher resolution when there is a good match for content, e.g. 4k@24p.