### PR TITLE
AdjustRefreshrate: Compare with original resolution not with a temporary

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -222,6 +222,8 @@ void CBaseRenderer::FindResolutionFromFpsMatch(float fps, float& weight)
 RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RESOLUTION current, float& weight)
 {
   RESOLUTION_INFO curr = g_graphicsContext.GetResInfo(current);
+  // backup original info as curr is used as a temporary in the loop below
+  RESOLUTION_INFO orig = curr;
 
   float fRefreshRate = fps;
 
@@ -234,9 +236,9 @@ RESOLUTION CBaseRenderer::FindClosestResolution(float fps, float multiplier, RES
 
     //discard lower resolutions (and interlaced/3D flags)
     //or have a too low refreshrate
-    if (info.iScreenWidth  < curr.iScreenWidth
-    ||  info.iScreenHeight < curr.iScreenHeight
-    ||  info.iScreen       != curr.iScreen
+    if (info.iScreenWidth  < orig.iScreenWidth
+    ||  info.iScreenHeight < orig.iScreenHeight
+    ||  info.iScreen       != orig.iScreen
     ||  (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK)
     ||  info.fRefreshRate < (fRefreshRate * multiplier / 1.001) - 0.001)
       continue;


### PR DESCRIPTION
Please squash this one to: db9d3e4e2a970ad60aa5c50f6ff01fb4db824374 

The old code would try 1920x1080 for a 1080i50 source first and afterwards 1280x720@50p would not be settable anymore cause of the comparison with curr which already would be 1920x1080 then.