### PR TITLE
Hwdecrenderer gles vtb

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -1185,6 +1185,8 @@
 		DFDE5D521AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */; };
 		DFDE5D531AE5658200EE53AD /* PictureScalingAlgorithm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDE5D4F1AE5658200EE53AD /* PictureScalingAlgorithm.cpp */; };
 		DFE4095B17417FDF00473BD9 /* LegacyPathTranslation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */; };
+		DFE9EE591BA60ADD00D9E141 /* RendererVTB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE9EE571BA60ADD00D9E141 /* RendererVTB.cpp */; };
+		DFE9EE5A1BA60ADD00D9E141 /* RendererVTB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFE9EE571BA60ADD00D9E141 /* RendererVTB.cpp */; };
 		DFEA4B4E1B5271A900562321 /* AddonCallbacksAudioDSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C973CE31B50378E0002A874 /* AddonCallbacksAudioDSP.cpp */; };
 		DFEA4B4F1B5271AA00562321 /* AddonCallbacksAudioDSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C973CE31B50378E0002A874 /* AddonCallbacksAudioDSP.cpp */; };
 		DFEA4B501B5271EB00562321 /* ActiveAEDSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C973CE71B5037EF0002A874 /* ActiveAEDSP.cpp */; };
@@ -4896,6 +4898,8 @@
 		DFDE5D501AE5658200EE53AD /* PictureScalingAlgorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PictureScalingAlgorithm.h; sourceTree = "<group>"; };
 		DFE4095917417FDF00473BD9 /* LegacyPathTranslation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyPathTranslation.cpp; sourceTree = "<group>"; };
 		DFE4095A17417FDF00473BD9 /* LegacyPathTranslation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyPathTranslation.h; sourceTree = "<group>"; };
+		DFE9EE571BA60ADD00D9E141 /* RendererVTB.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RendererVTB.cpp; path = xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.cpp; sourceTree = SOURCE_ROOT; };
+		DFE9EE581BA60ADD00D9E141 /* RendererVTB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RendererVTB.h; path = xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.h; sourceTree = SOURCE_ROOT; };
 		DFEB902519E9335E00728978 /* AEResample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEResample.h; sourceTree = "<group>"; };
 		DFEB902619E9337200728978 /* AEResampleFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEResampleFactory.cpp; sourceTree = "<group>"; };
 		DFEB902719E9337200728978 /* AEResampleFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEResampleFactory.h; sourceTree = "<group>"; };
@@ -7279,6 +7283,8 @@
 		7CBB101C1B1E1C0700E4FDE5 /* HwDecRender */ = {
 			isa = PBXGroup;
 			children = (
+				DFE9EE571BA60ADD00D9E141 /* RendererVTB.cpp */,
+				DFE9EE581BA60ADD00D9E141 /* RendererVTB.h */,
 				7CEC35211B960C1D00D31B0B /* RendererVDA.cpp */,
 				7CEC35221B960C1D00D31B0B /* RendererVDA.h */,
 			);
@@ -12211,6 +12217,7 @@
 				DFF0F38017528350002DA3A4 /* GUIDialogPVRRecordingInfo.cpp in Sources */,
 				DFF0F38117528350002DA3A4 /* GUIDialogPVRTimerSettings.cpp in Sources */,
 				DFF0F38217528350002DA3A4 /* PVRRecording.cpp in Sources */,
+				DFE9EE5A1BA60ADD00D9E141 /* RendererVTB.cpp in Sources */,
 				DFF0F38317528350002DA3A4 /* PVRRecordings.cpp in Sources */,
 				3994427C1A8DD920006C39E9 /* VideoLibraryScanningJob.cpp in Sources */,
 				DFF0F38417528350002DA3A4 /* PVRTimerInfoTag.cpp in Sources */,
@@ -13574,6 +13581,7 @@
 				7C14099F183224B8009F9411 /* SettingSection.cpp in Sources */,
 				7C1409A2183224B8009F9411 /* SettingsManager.cpp in Sources */,
 				7C1409A5183224B8009F9411 /* SettingUpdate.cpp in Sources */,
+				DFE9EE591BA60ADD00D9E141 /* RendererVTB.cpp in Sources */,
 				DF0ABB74183A94A30018445D /* Utf8Utils.cpp in Sources */,
 				7C1409AA184015C9009F9411 /* InfoExpression.cpp in Sources */,
 				AE4E87A717354C4A00D15206 /* XSLTUtils.cpp in Sources */,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.cpp
@@ -1,0 +1,294 @@
+/*
+ *      Copyright (C) 2007-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "RendererVTB.h"
+
+#if defined(TARGET_DARWIN_IOS)
+#include "cores/IPlayer.h"
+#include "DVDCodecs/Video/DVDVideoCodecVideoToolBox.h"
+#include "utils/log.h"
+#include "utils/GLUtils.h"
+#include "settings/MediaSettings.h"
+#include "windowing/WindowingFactory.h"
+#include "osx/DarwinUtils.h"
+
+CRendererVTB::CRendererVTB()
+{
+
+}
+
+CRendererVTB::~CRendererVTB()
+{
+
+}
+
+void CRendererVTB::AddVideoPictureHW(DVDVideoPicture &picture, int index)
+{
+  YUVBUFFER &buf = m_buffers[index];
+  if (buf.hwDec)
+    CVBufferRelease((struct __CVBuffer *)buf.hwDec);
+  buf.hwDec = picture.cvBufferRef;
+  // retain another reference, this way VideoPlayer and renderer can issue releases.
+  CVBufferRetain(picture.cvBufferRef);
+}
+
+void CRendererVTB::ReleaseBuffer(int idx)
+{
+  YUVBUFFER &buf = m_buffers[idx];
+  if (buf.hwDec)
+    CVBufferRelease((struct __CVBuffer *)buf.hwDec);
+  buf.hwDec = NULL;
+}
+
+int CRendererVTB::GetImage(YV12Image *image, int source, bool readonly)
+{
+  return source;
+}
+
+bool CRendererVTB::Supports(EINTERLACEMETHOD method)
+{
+  return false;
+}
+
+bool CRendererVTB::Supports(EDEINTERLACEMODE mode)
+{
+  return false;
+}
+
+EINTERLACEMETHOD CRendererVTB::AutoInterlaceMethod()
+{
+  return VS_INTERLACEMETHOD_NONE;
+}
+
+bool CRendererVTB::LoadShadersHook()
+{
+  float ios_version = CDarwinUtils::GetIOSVersion();
+  CLog::Log(LOGNOTICE, "GL: Using CVBREF render method");
+  m_textureTarget = GL_TEXTURE_2D;
+
+  if (ios_version < 5.0 && m_format == RENDER_FMT_YUV420P)
+  {
+    CLog::Log(LOGNOTICE, "GL: Using software color conversion/RGBA render method");
+    m_renderMethod = RENDER_SW;
+  }
+  else
+  {
+    m_renderMethod = RENDER_CVREF;
+  }
+  ReorderDrawPoints();// cvref needs a reorder because its flipped in y direction
+
+  return false;
+}
+
+bool CRendererVTB::RenderHook(int index)
+{
+  YUVPLANE &plane = m_buffers[index].fields[m_currentField][0];
+  
+  glDisable(GL_DEPTH_TEST);
+  
+  glEnable(m_textureTarget);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(m_textureTarget, plane.id);
+  
+  g_Windowing.EnableGUIShader(SM_TEXTURE_RGBA);
+  
+  GLint   contrastLoc = g_Windowing.GUIShaderGetContrast();
+  glUniform1f(contrastLoc, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Contrast * 0.02f);
+  GLint   brightnessLoc = g_Windowing.GUIShaderGetBrightness();
+  glUniform1f(brightnessLoc, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Brightness * 0.01f - 0.5f);
+  
+  GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip
+  GLfloat ver[4][4];
+  GLfloat tex[4][2];
+  GLfloat col[3] = {1.0f, 1.0f, 1.0f};
+  
+  GLint   posLoc = g_Windowing.GUIShaderGetPos();
+  GLint   texLoc = g_Windowing.GUIShaderGetCoord0();
+  GLint   colLoc = g_Windowing.GUIShaderGetCol();
+  
+  glVertexAttribPointer(posLoc, 4, GL_FLOAT, 0, 0, ver);
+  glVertexAttribPointer(texLoc, 2, GL_FLOAT, 0, 0, tex);
+  glVertexAttribPointer(colLoc, 3, GL_FLOAT, 0, 0, col);
+  
+  glEnableVertexAttribArray(posLoc);
+  glEnableVertexAttribArray(texLoc);
+  glEnableVertexAttribArray(colLoc);
+  
+  // Set vertex coordinates
+  for(int i = 0; i < 4; i++)
+  {
+    ver[i][0] = m_rotatedDestCoords[i].x;
+    ver[i][1] = m_rotatedDestCoords[i].y;
+    ver[i][2] = 0.0f;// set z to 0
+    ver[i][3] = 1.0f;
+  }
+  
+  // Set texture coordinates (corevideo is flipped in y)
+  tex[0][0] = tex[3][0] = plane.rect.x1;
+  tex[0][1] = tex[1][1] = plane.rect.y2;
+  tex[1][0] = tex[2][0] = plane.rect.x2;
+  tex[2][1] = tex[3][1] = plane.rect.y1;
+  
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+  
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(texLoc);
+  glDisableVertexAttribArray(colLoc);
+  
+  g_Windowing.DisableGUIShader();
+  VerifyGLState();
+  
+  glDisable(m_textureTarget);
+  VerifyGLState();
+  return true;
+}
+
+bool CRendererVTB::CreateTexture(int index)
+{
+  YV12Image &im     = m_buffers[index].image;
+  YUVFIELDS &fields = m_buffers[index].fields;
+  YUVPLANE  &plane  = fields[0][0];
+  
+  DeleteTexture(index);
+  
+  memset(&im    , 0, sizeof(im));
+  memset(&fields, 0, sizeof(fields));
+  
+  im.height = m_sourceHeight;
+  im.width  = m_sourceWidth;
+  
+  plane.texwidth  = im.width;
+  plane.texheight = im.height;
+  plane.pixpertex_x = 1;
+  plane.pixpertex_y = 1;
+  
+  if(m_renderMethod & RENDER_POT)
+  {
+    plane.texwidth  = NP2(plane.texwidth);
+    plane.texheight = NP2(plane.texheight);
+  }
+  glEnable(m_textureTarget);
+  glGenTextures(1, &plane.id);
+  VerifyGLState();
+  
+  glBindTexture(m_textureTarget, plane.id);
+#if !TARGET_OS_IPHONE
+#ifdef GL_UNPACK_ROW_LENGTH
+  // Set row pixels
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, m_sourceWidth);
+#endif
+#ifdef GL_TEXTURE_STORAGE_HINT_APPLE
+  // Set storage hint. Can also use GL_STORAGE_SHARED_APPLE see docs.
+  glTexParameteri(m_textureTarget, GL_TEXTURE_STORAGE_HINT_APPLE , GL_STORAGE_CACHED_APPLE);
+  // Set client storage
+#endif
+  glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_TRUE);
+#endif
+  
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  // This is necessary for non-power-of-two textures
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+  glTexImage2D(m_textureTarget, 0, GL_RGBA, plane.texwidth, plane.texheight, 0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, NULL);
+  
+#if !TARGET_OS_IPHONE
+  // turn off client storage so it doesn't get picked up for the next texture
+  glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_FALSE);
+#endif
+  glBindTexture(m_textureTarget, 0);
+  glDisable(m_textureTarget);
+
+  return true;
+}
+
+void CRendererVTB::DeleteTexture(int index)
+{
+  YUVPLANE &plane = m_buffers[index].fields[0][0];
+  
+  if (m_buffers[index].hwDec)
+    CVBufferRelease((struct __CVBuffer *)m_buffers[index].hwDec);
+  m_buffers[index].hwDec = NULL;
+  
+  if(plane.id && glIsTexture(plane.id))
+    glDeleteTextures(1, &plane.id);
+  plane.id = 0;
+}
+
+bool CRendererVTB::UploadTexture(int index)
+{
+  bool ret = false;
+  CVBufferRef cvBufferRef = (struct __CVBuffer *)m_buffers[index].hwDec;
+  
+  if (cvBufferRef)
+  {
+    YUVPLANE &plane = m_buffers[index].fields[0][0];
+    
+    CVPixelBufferLockBaseAddress(cvBufferRef, kCVPixelBufferLock_ReadOnly);
+#if !TARGET_OS_IPHONE
+    int rowbytes = CVPixelBufferGetBytesPerRow(cvBufferRef);
+#endif
+    int bufferWidth = CVPixelBufferGetWidth(cvBufferRef);
+    int bufferHeight = CVPixelBufferGetHeight(cvBufferRef);
+    unsigned char *bufferBase = (unsigned char *)CVPixelBufferGetBaseAddress(cvBufferRef);
+    
+    glEnable(m_textureTarget);
+    VerifyGLState();
+    
+    glBindTexture(m_textureTarget, plane.id);
+#if !TARGET_OS_IPHONE
+#ifdef GL_UNPACK_ROW_LENGTH
+    // Set row pixels
+    glPixelStorei( GL_UNPACK_ROW_LENGTH, rowbytes);
+#endif
+#ifdef GL_TEXTURE_STORAGE_HINT_APPLE
+    // Set storage hint. Can also use GL_STORAGE_SHARED_APPLE see docs.
+    glTexParameteri(m_textureTarget, GL_TEXTURE_STORAGE_HINT_APPLE , GL_STORAGE_CACHED_APPLE);
+#endif
+#endif
+    
+    // Using BGRA extension to pull in video frame data directly
+    glTexSubImage2D(m_textureTarget, 0, 0, 0, bufferWidth, bufferHeight, GL_BGRA_EXT, GL_UNSIGNED_BYTE, bufferBase);
+    
+#if !TARGET_OS_IPHONE
+#ifdef GL_UNPACK_ROW_LENGTH
+    // Unset row pixels
+    glPixelStorei( GL_UNPACK_ROW_LENGTH, 0);
+#endif
+#endif
+    glBindTexture(m_textureTarget, 0);
+    
+    glDisable(m_textureTarget);
+    VerifyGLState();
+    
+    CVPixelBufferUnlockBaseAddress(cvBufferRef, kCVPixelBufferLock_ReadOnly);
+    CVBufferRelease((struct __CVBuffer *)m_buffers[index].hwDec);
+    m_buffers[index].hwDec = NULL;
+    
+    plane.flipindex = m_buffers[index].flipindex;
+    ret = true;
+  }
+  
+  CalculateTextureSourceRects(index, 1);
+  return ret;
+}
+
+#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTB.h
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2007-2015 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "system.h"
+
+#if defined(TARGET_DARWIN_IOS)
+
+#include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
+
+class CRendererVTB : public CLinuxRendererGLES
+{
+public:
+  CRendererVTB();
+  virtual ~CRendererVTB();
+
+  // Player functions
+  virtual void AddVideoPictureHW(DVDVideoPicture &picture, int index);
+  virtual void ReleaseBuffer(int idx);
+  virtual int  GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
+
+  // Feature support
+  virtual bool Supports(EINTERLACEMETHOD method);
+  virtual bool Supports(EDEINTERLACEMODE mode);
+  
+  // hooks for hw dec renderer
+  virtual bool RenderHook(int index);  
+
+  virtual EINTERLACEMETHOD AutoInterlaceMethod();
+
+protected:
+  virtual bool LoadShadersHook();
+
+  // textures
+  virtual bool UploadTexture(int index);
+  virtual void DeleteTexture(int index);
+  virtual bool CreateTexture(int index);
+};
+
+#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -58,13 +58,6 @@ extern "C" {
 #include "yuv2rgb.neon.h"
 #include "utils/CPUInfo.h"
 #endif
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-#include "DVDCodecs/Video/DVDVideoCodecVideoToolBox.h"
-#include <CoreVideo/CoreVideo.h>
-#endif
-#ifdef TARGET_DARWIN_IOS
-#include "osx/DarwinUtils.h"
-#endif
 #if defined(HAS_LIBSTAGEFRIGHT)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -103,9 +96,6 @@ CLinuxRendererGLES::YUVBUFFER::YUVBUFFER()
 #ifdef HAVE_LIBOPENMAX
   openMaxBufferHolder = NULL;
 #endif
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  cvBufferRef = NULL;
-#endif
 #ifdef HAS_LIBSTAGEFRIGHT
   stf = NULL;
   eglimg = EGL_NO_IMAGE_KHR;
@@ -116,6 +106,7 @@ CLinuxRendererGLES::YUVBUFFER::YUVBUFFER()
 #ifdef HAS_IMXVPU
   IMXBuffer = NULL;
 #endif
+  hwDec = NULL;
 }
 
 CLinuxRendererGLES::YUVBUFFER::~YUVBUFFER()
@@ -141,11 +132,6 @@ CLinuxRendererGLES::CLinuxRendererGLES()
   m_pVideoFilterShader = NULL;
   m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   m_scalingMethodGui = (ESCALINGMETHOD)-1;
-
-  // default texture handlers to YUV
-  m_textureUpload = &CLinuxRendererGLES::UploadYV12Texture;
-  m_textureCreate = &CLinuxRendererGLES::CreateYV12Texture;
-  m_textureDelete = &CLinuxRendererGLES::DeleteYV12Texture;
 
   m_rgbBuffer = NULL;
   m_rgbBufferSize = 0;
@@ -203,13 +189,13 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
     // call to LoadShaders
     glFinish();
     for (int i = 0 ; i < NUM_BUFFERS ; i++)
-      (this->*m_textureDelete)(i);
+      DeleteTexture(i);
 
      // create the yuv textures
     LoadShaders();
 
     for (int i = 0 ; i < m_NumYV12Buffers ; i++)
-      (this->*m_textureCreate)(i);
+      CreateTexture(i);
 
     m_bValidated = true;
     return true;
@@ -304,13 +290,6 @@ int CLinuxRendererGLES::GetImage(YV12Image *image, int source, bool readonly)
   {
     return source;
   }
-
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  if (m_renderMethod & RENDER_CVREF )
-  {
-    return source;
-  }
-#endif
 
   YV12Image &im = m_buffers[source].image;
 
@@ -492,7 +471,7 @@ void CLinuxRendererGLES::Flush()
   glFinish();
 
   for (int i = 0 ; i < m_NumYV12Buffers ; i++)
-    (this->*m_textureDelete)(i);
+    DeleteTexture(i);
 
   glFinish();
   m_bValidated = false;
@@ -796,91 +775,78 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 
 void CLinuxRendererGLES::LoadShaders(int field)
 {
-#ifdef TARGET_DARWIN_IOS
-  float ios_version = CDarwinUtils::GetIOSVersion();
-#endif
-  int requestedMethod = CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_RENDERMETHOD);
-  CLog::Log(LOGDEBUG, "GL: Requested render method: %d", requestedMethod);
-
-  ReleaseShaders();
-
-  switch(requestedMethod)
+  if (!LoadShadersHook())
   {
-    case RENDER_METHOD_AUTO:
-    case RENDER_METHOD_GLSL:
-      if (m_format == RENDER_FMT_OMXEGL)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using OMXEGL RGBA render method");
-        m_renderMethod = RENDER_OMXEGL;
-        break;
-      }
-      else if (m_format == RENDER_FMT_EGLIMG)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using EGL Image render method");
-        m_renderMethod = RENDER_EGLIMG;
-        break;
-      }
-      else if (m_format == RENDER_FMT_MEDIACODEC)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using MediaCodec render method");
-        m_renderMethod = RENDER_MEDIACODEC;
-        break;
-      }
-      else if (m_format == RENDER_FMT_IMXMAP)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using IMXMAP render method");
-        m_renderMethod = RENDER_IMXMAP;
-        break;
-      }
-      else if (m_format == RENDER_FMT_BYPASS)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using BYPASS render method");
-        m_renderMethod = RENDER_BYPASS;
-        break;
-      }
-      else if (m_format == RENDER_FMT_CVBREF)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using CoreVideoRef RGBA render method");
-        m_renderMethod = RENDER_CVREF;
-        break;
-      }
-      #if defined(TARGET_DARWIN_IOS)
-      else if (ios_version < 5.0 && m_format == RENDER_FMT_YUV420P)
-      {
-        CLog::Log(LOGNOTICE, "GL: Using software color conversion/RGBA render method");
-        m_renderMethod = RENDER_SW;
-        break;
-      }
-      #endif
-      // Try GLSL shaders if supported and user requested auto or GLSL.
-      if (glCreateProgram)
-      {
-        // create regular scan shader
-        CLog::Log(LOGNOTICE, "GL: Selecting Single Pass YUV 2 RGB shader");
+    int requestedMethod = CSettings::GetInstance().GetInt(CSettings::SETTING_VIDEOPLAYER_RENDERMETHOD);
+    CLog::Log(LOGDEBUG, "GL: Requested render method: %d", requestedMethod);
 
-        m_pYUVProgShader = new YUV2RGBProgressiveShader(false, m_iFlags, m_format);
-        m_pYUVBobShader = new YUV2RGBBobShader(false, m_iFlags, m_format);
-        if ((m_pYUVProgShader && m_pYUVProgShader->CompileAndLink())
-            && (m_pYUVBobShader && m_pYUVBobShader->CompileAndLink()))
+    ReleaseShaders();
+
+    switch(requestedMethod)
+    {
+      case RENDER_METHOD_AUTO:
+      case RENDER_METHOD_GLSL:
+        if (m_format == RENDER_FMT_OMXEGL)
         {
-          m_renderMethod = RENDER_GLSL;
-          UpdateVideoFilter();
+          CLog::Log(LOGNOTICE, "GL: Using OMXEGL RGBA render method");
+          m_renderMethod = RENDER_OMXEGL;
           break;
         }
-        else
+        else if (m_format == RENDER_FMT_EGLIMG)
         {
-          ReleaseShaders();
-          CLog::Log(LOGERROR, "GL: Error enabling YUV2RGB GLSL shader");
-          // drop through and try SW
+          CLog::Log(LOGNOTICE, "GL: Using EGL Image render method");
+          m_renderMethod = RENDER_EGLIMG;
+          break;
         }
-      }
-    case RENDER_METHOD_SOFTWARE:
-    default:
-      {
-        // Use software YUV 2 RGB conversion if user requested it or GLSL failed
-        m_renderMethod = RENDER_SW ;
-        CLog::Log(LOGNOTICE, "GL: Using software color conversion/RGBA rendering");
-      }
+        else if (m_format == RENDER_FMT_MEDIACODEC)
+        {
+          CLog::Log(LOGNOTICE, "GL: Using MediaCodec render method");
+          m_renderMethod = RENDER_MEDIACODEC;
+          break;
+        }
+        else if (m_format == RENDER_FMT_IMXMAP)
+        {
+          CLog::Log(LOGNOTICE, "GL: Using IMXMAP render method");
+          m_renderMethod = RENDER_IMXMAP;
+          break;
+        }
+        else if (m_format == RENDER_FMT_BYPASS)
+        {
+          CLog::Log(LOGNOTICE, "GL: Using BYPASS render method");
+          m_renderMethod = RENDER_BYPASS;
+          break;
+        }
+
+        // Try GLSL shaders if supported and user requested auto or GLSL.
+        if (glCreateProgram)
+        {
+          // create regular scan shader
+          CLog::Log(LOGNOTICE, "GL: Selecting Single Pass YUV 2 RGB shader");
+
+          m_pYUVProgShader = new YUV2RGBProgressiveShader(false, m_iFlags, m_format);
+          m_pYUVBobShader = new YUV2RGBBobShader(false, m_iFlags, m_format);
+          if ((m_pYUVProgShader && m_pYUVProgShader->CompileAndLink())
+              && (m_pYUVBobShader && m_pYUVBobShader->CompileAndLink()))
+          {
+            m_renderMethod = RENDER_GLSL;
+            UpdateVideoFilter();
+            break;
+          }
+          else
+          {
+            ReleaseShaders();
+            CLog::Log(LOGERROR, "GL: Error enabling YUV2RGB GLSL shader");
+            // drop through and try SW
+          }
+        }
+      case RENDER_METHOD_SOFTWARE:
+      default:
+        {
+          // Use software YUV 2 RGB conversion if user requested it or GLSL failed
+          m_renderMethod = RENDER_SW ;
+          CLog::Log(LOGNOTICE, "GL: Using software color conversion/RGBA rendering");
+        }
+    }
   }
 
   // determine whether GPU supports NPOT textures
@@ -892,57 +858,6 @@ void CLinuxRendererGLES::LoadShaders(int field)
   }
   else
     CLog::Log(LOGNOTICE, "GL: NPOT texture support detected");
-
-  // Now that we now the render method, setup texture function handlers
-  if (m_format == RENDER_FMT_CVBREF)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadCVRefTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateCVRefTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteCVRefTexture;
-  }
-  else if (m_format == RENDER_FMT_BYPASS)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadBYPASSTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateBYPASSTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteBYPASSTexture;
-  }
-  else if (m_format == RENDER_FMT_EGLIMG)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadEGLIMGTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateEGLIMGTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteEGLIMGTexture;
-  }
-  else if (m_format == RENDER_FMT_MEDIACODEC)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadSurfaceTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateSurfaceTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteSurfaceTexture;
-  }
-  else if (m_format == RENDER_FMT_NV12)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadNV12Texture;
-    m_textureCreate = &CLinuxRendererGLES::CreateNV12Texture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteNV12Texture;
-  }
-  else if (m_format == RENDER_FMT_IMXMAP)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadIMXMAPTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateIMXMAPTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteIMXMAPTexture;
-  }
-  else if (m_format == RENDER_FMT_OMXEGL)
-  {
-    m_textureUpload = &CLinuxRendererGLES::UploadOpenMaxTexture;
-    m_textureCreate = &CLinuxRendererGLES::CreateOpenMaxTexture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteOpenMaxTexture;
-  }
-   else
-  {
-    // default to YV12 texture handlers
-    m_textureUpload = &CLinuxRendererGLES::UploadYV12Texture;
-    m_textureCreate = &CLinuxRendererGLES::CreateYV12Texture;
-    m_textureDelete = &CLinuxRendererGLES::DeleteYV12Texture;
-  }
 
   if (m_oldRenderMethod != m_renderMethod)
   {
@@ -982,7 +897,7 @@ void CLinuxRendererGLES::UnInit()
 
   // YV12 textures
   for (int i = 0; i < NUM_BUFFERS; ++i)
-    (this->*m_textureDelete)(i);
+    DeleteTexture(i);
 
   if (m_sw_context)
   {
@@ -1022,14 +937,6 @@ inline void CLinuxRendererGLES::ReorderDrawPoints()
 void CLinuxRendererGLES::ReleaseBuffer(int idx)
 {
   YUVBUFFER &buf = m_buffers[idx];
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  if (m_renderMethod & RENDER_CVREF )
-  {
-    if (buf.cvBufferRef)
-      CVBufferRelease(buf.cvBufferRef);
-    buf.cvBufferRef = NULL;
-  }
-#endif
 #if defined(TARGET_ANDROID)
   if ( m_renderMethod & RENDER_MEDIACODEC )
   {
@@ -1048,6 +955,123 @@ void CLinuxRendererGLES::ReleaseBuffer(int idx)
 #endif
 }
 
+bool CLinuxRendererGLES::CreateTexture(int index)
+{
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    CreateBYPASSTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_EGLIMG)
+  {
+    CreateEGLIMGTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_MEDIACODEC)
+  {
+    CreateSurfaceTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_NV12)
+  {
+    CreateNV12Texture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_IMXMAP)
+  {
+    CreateIMXMAPTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_OMXEGL)
+  {
+    CreateOpenMaxTexture(index);
+    return true;
+  }
+  else
+  {
+    // default to YV12 texture handlers
+    CreateYV12Texture(index);
+    return true;
+  }
+
+  return false;
+}
+
+void CLinuxRendererGLES::DeleteTexture(int index)
+{
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    DeleteBYPASSTexture(index);
+  }
+  else if (m_format == RENDER_FMT_EGLIMG)
+  {
+    DeleteEGLIMGTexture(index);
+  }
+  else if (m_format == RENDER_FMT_MEDIACODEC)
+  {
+    DeleteSurfaceTexture(index);
+  }
+  else if (m_format == RENDER_FMT_NV12)
+  {
+    DeleteNV12Texture(index);
+  }
+  else if (m_format == RENDER_FMT_IMXMAP)
+  {
+    DeleteIMXMAPTexture(index);
+  }
+  else if (m_format == RENDER_FMT_OMXEGL)
+  {
+    DeleteOpenMaxTexture(index);
+  }
+  else
+  {
+    // default to YV12 texture handlers
+    DeleteYV12Texture(index);
+  }
+}
+
+bool CLinuxRendererGLES::UploadTexture(int index)
+{
+  // Now that we now the render method, setup texture function handlers
+  if (m_format == RENDER_FMT_BYPASS)
+  {
+    UploadBYPASSTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_EGLIMG)
+  {
+    UploadEGLIMGTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_MEDIACODEC)
+  {
+    UploadSurfaceTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_NV12)
+  {
+    UploadNV12Texture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_IMXMAP)
+  {
+    UploadIMXMAPTexture(index);
+    return true;
+  }
+  else if (m_format == RENDER_FMT_OMXEGL)
+  {
+    UploadOpenMaxTexture(index);
+    return true;
+  }
+  else
+  {
+    // default to YV12 texture handlers
+    UploadYV12Texture(index);
+    return true;
+  }
+  return false;
+}
+
 void CLinuxRendererGLES::Render(DWORD flags, int index)
 {
   // If rendered directly by the hardware
@@ -1064,9 +1088,13 @@ void CLinuxRendererGLES::Render(DWORD flags, int index)
   else
     m_currentField = FIELD_FULL;
 
-  (this->*m_textureUpload)(index);
-
-  if (m_renderMethod & RENDER_GLSL)
+  // call texture load function
+  if (!UploadTexture(index))
+    return;
+  
+  if (RenderHook(index))
+    ;
+  else if (m_renderMethod & RENDER_GLSL)
   {
     UpdateVideoFilter();
     switch(m_renderQuality)
@@ -1096,11 +1124,6 @@ void CLinuxRendererGLES::Render(DWORD flags, int index)
   else if (m_renderMethod & RENDER_EGLIMG)
   {
     RenderEglImage(index, m_currentField);
-    VerifyGLState();
-  }
-  else if (m_renderMethod & RENDER_CVREF)
-  {
-    RenderCoreVideoRef(index, m_currentField);
     VerifyGLState();
   }
   else if (m_renderMethod & RENDER_MEDIACODEC)
@@ -1760,70 +1783,6 @@ void CLinuxRendererGLES::RenderSurfaceTexture(int index, int field)
 #endif
 }
 
-void CLinuxRendererGLES::RenderCoreVideoRef(int index, int field)
-{
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  YUVPLANE &plane = m_buffers[index].fields[field][0];
-
-  glDisable(GL_DEPTH_TEST);
-
-  glEnable(m_textureTarget);
-  glActiveTexture(GL_TEXTURE0);
-  glBindTexture(m_textureTarget, plane.id);
-
-  g_Windowing.EnableGUIShader(SM_TEXTURE_RGBA);
-
-  GLint   contrastLoc = g_Windowing.GUIShaderGetContrast();
-  glUniform1f(contrastLoc, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Contrast * 0.02f);
-  GLint   brightnessLoc = g_Windowing.GUIShaderGetBrightness();
-  glUniform1f(brightnessLoc, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Brightness * 0.01f - 0.5f);
-
-  GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip
-  GLfloat ver[4][4];
-  GLfloat tex[4][2];
-  GLfloat col[3] = {1.0f, 1.0f, 1.0f};
-
-  GLint   posLoc = g_Windowing.GUIShaderGetPos();
-  GLint   texLoc = g_Windowing.GUIShaderGetCoord0();
-  GLint   colLoc = g_Windowing.GUIShaderGetCol();
-
-  glVertexAttribPointer(posLoc, 4, GL_FLOAT, 0, 0, ver);
-  glVertexAttribPointer(texLoc, 2, GL_FLOAT, 0, 0, tex);
-  glVertexAttribPointer(colLoc, 3, GL_FLOAT, 0, 0, col);
-
-  glEnableVertexAttribArray(posLoc);
-  glEnableVertexAttribArray(texLoc);
-  glEnableVertexAttribArray(colLoc);
-
-  // Set vertex coordinates
-  for(int i = 0; i < 4; i++)
-  {
-    ver[i][0] = m_rotatedDestCoords[i].x;
-    ver[i][1] = m_rotatedDestCoords[i].y;
-    ver[i][2] = 0.0f;// set z to 0
-    ver[i][3] = 1.0f;
-  }
-
-  // Set texture coordinates (corevideo is flipped in y)
-  tex[0][0] = tex[3][0] = plane.rect.x1;
-  tex[0][1] = tex[1][1] = plane.rect.y2;
-  tex[1][0] = tex[2][0] = plane.rect.x2;
-  tex[2][1] = tex[3][1] = plane.rect.y1;
-
-  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
-
-  glDisableVertexAttribArray(posLoc);
-  glDisableVertexAttribArray(texLoc);
-  glDisableVertexAttribArray(colLoc);
-
-  g_Windowing.DisableGUIShader();
-  VerifyGLState();
-
-  glDisable(m_textureTarget);
-  VerifyGLState();
-#endif
-}
-
 void CLinuxRendererGLES::RenderIMXMAPTexture(int index, int field)
 {
 }
@@ -2410,140 +2369,6 @@ void CLinuxRendererGLES::DeleteNV12Texture(int index)
 }
 
 //********************************************************************************************************
-// CoreVideoRef Texture creation, deletion, copying + clearing
-//********************************************************************************************************
-void CLinuxRendererGLES::UploadCVRefTexture(int index)
-{
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  CVBufferRef cvBufferRef = m_buffers[index].cvBufferRef;
-
-  if (cvBufferRef)
-  {
-    YUVPLANE &plane = m_buffers[index].fields[0][0];
-
-    CVPixelBufferLockBaseAddress(cvBufferRef, kCVPixelBufferLock_ReadOnly);
-    #if !TARGET_OS_IPHONE
-      int rowbytes = CVPixelBufferGetBytesPerRow(cvBufferRef);
-    #endif
-    int bufferWidth = CVPixelBufferGetWidth(cvBufferRef);
-    int bufferHeight = CVPixelBufferGetHeight(cvBufferRef);
-    unsigned char *bufferBase = (unsigned char *)CVPixelBufferGetBaseAddress(cvBufferRef);
-
-    glEnable(m_textureTarget);
-    VerifyGLState();
-
-    glBindTexture(m_textureTarget, plane.id);
-    #if !TARGET_OS_IPHONE
-      #ifdef GL_UNPACK_ROW_LENGTH
-        // Set row pixels
-        glPixelStorei( GL_UNPACK_ROW_LENGTH, rowbytes);
-      #endif
-      #ifdef GL_TEXTURE_STORAGE_HINT_APPLE
-        // Set storage hint. Can also use GL_STORAGE_SHARED_APPLE see docs.
-        glTexParameteri(m_textureTarget, GL_TEXTURE_STORAGE_HINT_APPLE , GL_STORAGE_CACHED_APPLE);
-      #endif
-    #endif
-
-    // Using BGRA extension to pull in video frame data directly
-    glTexSubImage2D(m_textureTarget, 0, 0, 0, bufferWidth, bufferHeight, GL_BGRA_EXT, GL_UNSIGNED_BYTE, bufferBase);
-
-    #if !TARGET_OS_IPHONE
-      #ifdef GL_UNPACK_ROW_LENGTH
-        // Unset row pixels
-        glPixelStorei( GL_UNPACK_ROW_LENGTH, 0);
-      #endif
-    #endif
-    glBindTexture(m_textureTarget, 0);
-
-    glDisable(m_textureTarget);
-    VerifyGLState();
-
-    CVPixelBufferUnlockBaseAddress(cvBufferRef, kCVPixelBufferLock_ReadOnly);
-    CVBufferRelease(m_buffers[index].cvBufferRef);
-    m_buffers[index].cvBufferRef = NULL;
-
-    plane.flipindex = m_buffers[index].flipindex;
-  }
-
-  CalculateTextureSourceRects(index, 1);
-#endif
-}
-void CLinuxRendererGLES::DeleteCVRefTexture(int index)
-{
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  YUVPLANE &plane = m_buffers[index].fields[0][0];
-
-  if (m_buffers[index].cvBufferRef)
-    CVBufferRelease(m_buffers[index].cvBufferRef);
-  m_buffers[index].cvBufferRef = NULL;
-
-  if(plane.id && glIsTexture(plane.id))
-    glDeleteTextures(1, &plane.id);
-  plane.id = 0;
-#endif
-}
-bool CLinuxRendererGLES::CreateCVRefTexture(int index)
-{
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  YV12Image &im     = m_buffers[index].image;
-  YUVFIELDS &fields = m_buffers[index].fields;
-  YUVPLANE  &plane  = fields[0][0];
-
-  DeleteCVRefTexture(index);
-
-  memset(&im    , 0, sizeof(im));
-  memset(&fields, 0, sizeof(fields));
-
-  im.height = m_sourceHeight;
-  im.width  = m_sourceWidth;
-
-  plane.texwidth  = im.width;
-  plane.texheight = im.height;
-  plane.pixpertex_x = 1;
-  plane.pixpertex_y = 1;
-
-  if(m_renderMethod & RENDER_POT)
-  {
-    plane.texwidth  = NP2(plane.texwidth);
-    plane.texheight = NP2(plane.texheight);
-  }
-  glEnable(m_textureTarget);
-  glGenTextures(1, &plane.id);
-  VerifyGLState();
-
-  glBindTexture(m_textureTarget, plane.id);
-  #if !TARGET_OS_IPHONE
-    #ifdef GL_UNPACK_ROW_LENGTH
-      // Set row pixels
-      glPixelStorei(GL_UNPACK_ROW_LENGTH, m_sourceWidth);
-    #endif
-    #ifdef GL_TEXTURE_STORAGE_HINT_APPLE
-      // Set storage hint. Can also use GL_STORAGE_SHARED_APPLE see docs.
-      glTexParameteri(m_textureTarget, GL_TEXTURE_STORAGE_HINT_APPLE , GL_STORAGE_CACHED_APPLE);
-      // Set client storage
-    #endif
-    glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_TRUE);
-  #endif
-
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	// This is necessary for non-power-of-two textures
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-  glTexImage2D(m_textureTarget, 0, GL_RGBA, plane.texwidth, plane.texheight, 0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, NULL);
-
-  #if !TARGET_OS_IPHONE
-    // turn off client storage so it doesn't get picked up for the next texture
-    glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_FALSE);
-  #endif
-  glBindTexture(m_textureTarget, 0);
-  glDisable(m_textureTarget);
-#endif
-  return true;
-}
-
-//********************************************************************************************************
 // BYPASS creation, deletion, copying + clearing
 //********************************************************************************************************
 void CLinuxRendererGLES::UploadBYPASSTexture(int index)
@@ -2886,8 +2711,6 @@ bool CLinuxRendererGLES::Supports(EDEINTERLACEMODE mode)
   if(m_renderMethod & RENDER_OMXEGL)
     return false;
 
-  if(m_renderMethod & RENDER_CVREF)
-    return false;
 
   if(mode == VS_DEINTERLACEMODE_AUTO
   || mode == VS_DEINTERLACEMODE_FORCE)
@@ -2923,9 +2746,6 @@ bool CLinuxRendererGLES::Supports(EINTERLACEMETHOD method)
     else
       return false;
   }
-
-  if(m_renderMethod & RENDER_CVREF)
-    return false;
 
   if(method == VS_INTERLACEMETHOD_AUTO)
     return true;
@@ -2992,9 +2812,6 @@ EINTERLACEMETHOD CLinuxRendererGLES::AutoInterlaceMethod()
   if(m_renderMethod & RENDER_MEDIACODEC)
     return VS_INTERLACEMETHOD_RENDER_BOB_INVERTED;
 
-  if(m_renderMethod & RENDER_CVREF)
-    return VS_INTERLACEMETHOD_NONE;
-
   if(m_renderMethod & RENDER_IMXMAP)
     return VS_INTERLACEMETHOD_IMX_FASTMOTION;
 
@@ -3036,17 +2853,6 @@ void CLinuxRendererGLES::AddProcessor(COpenMax* openMax, DVDVideoPicture *pictur
   if (buf.openMaxBufferHolder) {
     buf.openMaxBufferHolder->Acquire();
   }
-}
-#endif
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-void CLinuxRendererGLES::AddProcessor(struct __CVBuffer *cvBufferRef, int index)
-{
-  YUVBUFFER &buf = m_buffers[index];
-  if (buf.cvBufferRef)
-    CVBufferRelease(buf.cvBufferRef);
-  buf.cvBufferRef = cvBufferRef;
-  // retain another reference, this way VideoPlayer and renderer can issue releases.
-  CVBufferRetain(buf.cvBufferRef);
 }
 #endif
 #ifdef HAS_LIBSTAGEFRIGHT

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -162,9 +162,6 @@ public:
 #ifdef HAVE_LIBOPENMAX
   virtual void         AddProcessor(COpenMax* openMax, DVDVideoPicture *picture, int index);
 #endif
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-  virtual void         AddProcessor(struct __CVBuffer *cvBufferRef, int index);
-#endif
 #ifdef HAS_LIBSTAGEFRIGHT
   virtual void         AddProcessor(CDVDVideoCodecStageFright* stf, EGLImageKHR eglimg, int index);
 #endif
@@ -188,9 +185,9 @@ protected:
   void UpdateVideoFilter();
 
   // textures
-  void (CLinuxRendererGLES::*m_textureUpload)(int index);
-  void (CLinuxRendererGLES::*m_textureDelete)(int index);
-  bool (CLinuxRendererGLES::*m_textureCreate)(int index);
+  virtual bool UploadTexture(int index);
+  virtual void DeleteTexture(int index);
+  virtual bool CreateTexture(int index);
 
   void UploadYV12Texture(int index);
   void DeleteYV12Texture(int index);
@@ -232,9 +229,12 @@ protected:
   void RenderSoftware(int index, int field);      // single pass s/w yuv2rgb renderer
   void RenderOpenMax(int index, int field);       // OpenMAX rgb texture
   void RenderEglImage(int index, int field);       // Android OES texture
-  void RenderCoreVideoRef(int index, int field);  // CoreVideo reference
   void RenderSurfaceTexture(int index, int field);// MediaCodec rendering using SurfaceTexture
   void RenderIMXMAPTexture(int index, int field); // IMXMAP rendering
+  
+  // hooks for HwDec Renderered
+  virtual bool LoadShadersHook() { return false; };
+  virtual bool RenderHook(int idx) { return false; };
 
   CFrameBufferObject m_fbo;
 
@@ -290,9 +290,6 @@ protected:
 #ifdef HAVE_LIBOPENMAX
     OpenMaxVideoBufferHolder *openMaxBufferHolder;
 #endif
-#ifdef HAVE_VIDEOTOOLBOXDECODER
-    struct __CVBuffer *cvBufferRef;
-#endif
 #ifdef HAS_LIBSTAGEFRIGHT
     CDVDVideoCodecStageFright* stf;
     EGLImageKHR eglimg;
@@ -304,6 +301,7 @@ protected:
 #ifdef HAS_IMXVPU
     CDVDVideoCodecIMXBuffer *IMXBuffer;
 #endif
+    void *hwDec;
   };
 
   typedef YUVBUFFER          YUVBUFFERS[NUM_BUFFERS];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -47,6 +47,9 @@
   #include "HwDecRender/MMALRenderer.h"
 #elif HAS_GLES == 2
   #include "LinuxRendererGLES.h"
+#if defined(HAVE_VIDEOTOOLBOXDECODER)
+#include "HWDecRender/RendererVTB.h"
+#endif
 #elif defined(HAS_DX)
   #include "WinRenderer.h"
 #elif defined(HAS_SDL)
@@ -633,7 +636,16 @@ void CRenderManager::CreateRenderer()
 #if defined(HAS_MMAL)
     m_pRenderer = new CMMALRenderer();
 #elif HAS_GLES == 2
-    m_pRenderer = new CLinuxRendererGLES();
+    if (m_format == RENDER_FMT_CVBREF)
+    {
+#if defined(HAVE_VIDEOTOOLBOXDECODER)
+      m_pRenderer = new CRendererVTB;
+#endif
+    }
+    else if (m_format != RENDER_FMT_NONE)
+    {
+      m_pRenderer = new CLinuxRendererGLES;
+    }
 #elif defined(HAS_DX)
     m_pRenderer = new CWinRenderer();
 #endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/GLSLOutput.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/GLSLOutput.cpp
@@ -82,7 +82,9 @@ void GLSLOutput::OnCompiledAndLinked(GLuint programHandle)
     glActiveTexture(GL_TEXTURE0 + m_uDither);
     glBindTexture(GL_TEXTURE_2D, m_tDitherTex);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+#if HAS_GLES != 2
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
@@ -188,6 +188,12 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, unsigned flags, ERenderF
   m_hStretch = -1;
   m_hStep    = -1;
 
+  // get defines from the output stage if used
+  m_glslOutput = output;
+  if (m_glslOutput) {
+    m_defines += m_glslOutput->GetDefines();
+  }
+
 #ifdef HAS_GL
   if(rect)
     m_defines += "#define XBMC_texture_rectangle 1\n";
@@ -204,12 +210,6 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect, unsigned flags, ERenderF
     m_defines += "#define XBMC_STRETCH 1\n";
   else
     m_defines += "#define XBMC_STRETCH 0\n";
-
-  // get defines from the output stage if used
-  m_glslOutput = output;
-  if (m_glslOutput) {
-    m_defines += m_glslOutput->GetDefines();
-  }
 
   if (m_format == RENDER_FMT_YUV420P ||
       m_format == RENDER_FMT_YUV420P10 ||


### PR DESCRIPTION
Here is the start of the gles video renderer refactor. This adds RendererVTB and makes gles software rendering work.

All other hw dec renderers need to be moved into their own implementations by the code maintainers of those (though its pretty straight forward - basically derive a class from LinuxRendererGLES - search for the hw dec define in it and move that stuff into the overridden methods in the impl.)

Fernet i think i got the intention now ;)