### PR TITLE
Add X11 EGL depends build support and DVDVideoCodec.* cleanup

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -30,6 +30,7 @@ ifeq ($(OS),ios)
   EXCLUDED_DEPENDS = libcec libusb
 endif
 
+# TODO: Check use of libGLEW still needed with EGL
 ifeq ($(OS),osx)
   DEPENDS += libGLEW libsdl
   EXCLUDED_DEPENDS = libusb
@@ -125,7 +126,24 @@ test-dependencies:
 distclean::
 	for d in $(DEPENDS); do $(MAKE) -C $$d distclean; done
 
-linux-system-libs:
+linux-system-libs-egl:
+	[ -f $(PREFIX)/lib/pkgconfig/egl.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/egl.pc $(PREFIX)/lib/pkgconfig/egl.pc
+	[ -f $(PREFIX)/lib/pkgconfig/damageproto.pc ] || ln -s  /usr/share/pkgconfig/damageproto.pc $(PREFIX)/lib/pkgconfig/damageproto.pc
+	[ -f $(PREFIX)/lib/pkgconfig/fixesproto.pc ] || ln -s  /usr/share/pkgconfig/fixesproto.pc $(PREFIX)/lib/pkgconfig/fixesproto.pc
+	[ -f $(PREFIX)/lib/pkgconfig/wayland-egl.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/wayland-egl.pc $(PREFIX)/lib/pkgconfig/wayland-egl.pc
+	[ -f $(PREFIX)/lib/pkgconfig/x11-xcb.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/x11-xcb.pc $(PREFIX)/lib/pkgconfig/x11-xcb.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xcb-dri2.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xcb-dri2.pc $(PREFIX)/lib/pkgconfig/xcb-dri2.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xcb-dri3.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xcb-dri3.pc $(PREFIX)/lib/pkgconfig/xcb-dri3.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xcb-glx.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xcb-glx.pc $(PREFIX)/lib/pkgconfig/xcb-glx.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xcb-present.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xcb-present.pc $(PREFIX)/lib/pkgconfig/xcb-present.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xcb-sync.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xcb-sync.pc $(PREFIX)/lib/pkgconfig/xcb-sync.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xdamage.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/xdamage.pc $(PREFIX)/lib/pkgconfig/xdamage.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xf86vidmodeproto.pc ] || ln -s /usr/share/pkgconfig/xf86vidmodeproto.pc $(PREFIX)/lib/pkgconfig/xf86vidmodeproto.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xfixes.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xfixes.pc $(PREFIX)/lib/pkgconfig/xfixes.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xshmfence.pc ] || ln -s  /usr/lib/$(HOST)/pkgconfig/xshmfence.pc $(PREFIX)/lib/pkgconfig/xshmfence.pc
+	[ -f $(PREFIX)/lib/pkgconfig/xxf86vm.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/xxf86vm.pc $(PREFIX)/lib/pkgconfig/xxf86vm.pc
+
+linux-system-libs: linux-system-libs-egl
 	[ -f $(PREFIX)/lib/pkgconfig/x11.pc ] || ln -s /usr/lib/$(HOST)/pkgconfig/x11.pc $(PREFIX)/lib/pkgconfig/x11.pc
 	[ -f $(PREFIX)/lib/pkgconfig/xproto.pc ] || ln -s /usr/share/pkgconfig/xproto.pc $(PREFIX)/lib/pkgconfig/xproto.pc
 	[ -f $(PREFIX)/lib/pkgconfig/kbproto.pc ] || ln -s /usr/share/pkgconfig/kbproto.pc $(PREFIX)/lib/pkgconfig/kbproto.pc

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -19,9 +19,9 @@
  */
 
 #include "DVDVideoCodec.h"
-#include "windowing/WindowingFactory.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
+#include "windowing/WindowingFactory.h"
 
 bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::string &value, const CSetting *setting, void *data)
 {
@@ -37,12 +37,12 @@ bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::s
   bool isIntel = (gpuvendor.compare(0, 5, "intel") == 0);
 
   // nvidia does only need mpeg-4 setting
-  if (isNvidia) 
+  if (isNvidia)
   {
     if (settingId == CSettings::SETTING_VIDEOPLAYER_USEVDPAUMPEG4)
       return true;
 
-    return false; //will also hide intel settings on nvidia hardware
+    return false; // will also hide intel settings on nvidia hardware
   }
   else if (isIntel) // intel needs vc1, mpeg-2 and mpeg4 setting
   {
@@ -53,7 +53,7 @@ bool CDVDVideoCodec::IsSettingVisible(const std::string &condition, const std::s
     if (settingId == CSettings::SETTING_VIDEOPLAYER_USEVAAPIMPEG2)
       return true;
 
-    return false; //this will also hide nvidia settings on intel hardware
+    return false; // this will also hide nvidia settings on intel hardware
   }
   // if we don't know the hardware we are running on e.g. amd oss vdpau 
   // or fglrx with xvba-driver we show everything
@@ -65,14 +65,19 @@ bool CDVDVideoCodec::IsCodecDisabled(DVDCodecAvailableType* map, unsigned int si
   int index = -1;
   for (unsigned int i = 0; i < size; ++i)
   {
-    if(map[i].codec == id)
+    if (map[i].codec == id)
     {
       index = (int) i;
       break;
     }
   }
-  if(index > -1)
-    return (!CSettings::GetInstance().GetBool(map[index].setting) || !CDVDVideoCodec::IsSettingVisible("unused", "unused", CSettings::GetInstance().GetSetting(map[index].setting), NULL));
+  if (index > -1)
+  {
+    return (!CSettings::GetInstance().GetBool(map[index].setting) ||
+            !CDVDVideoCodec::IsSettingVisible("unused", "unused",
+                                              CSettings::GetInstance().GetSetting(map[index].setting),
+                                              NULL));
+  }
 
-  return false; //don't disable what we don't have
+  return false; // don't disable what we don't have
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -21,20 +21,18 @@
  */
 
 #include "system.h"
-
-#include <vector>
-#include <string>
 #include "cores/VideoPlayer/VideoRenderers/RenderFormats.h"
-
-
 
 extern "C" {
 #include "libavcodec/avcodec.h"
 }
 
+#include <vector>
+#include <string>
+
 class CSetting;
 
-struct DVDCodecAvailableType 
+struct DVDCodecAvailableType
 {
   AVCodecID codec;
   const char* setting;
@@ -42,10 +40,10 @@ struct DVDCodecAvailableType
 
 // when modifying these structures, make sure you update all codecs accordingly
 #define FRAME_TYPE_UNDEF 0
-#define FRAME_TYPE_I 1
-#define FRAME_TYPE_P 2
-#define FRAME_TYPE_B 3
-#define FRAME_TYPE_D 4
+#define FRAME_TYPE_I     1
+#define FRAME_TYPE_P     2
+#define FRAME_TYPE_B     3
+#define FRAME_TYPE_D     4
 
 namespace DXVA { class CRenderPicture; }
 namespace VAAPI { class CVaapiRenderPicture; }
@@ -69,7 +67,7 @@ struct DVDVideoPicture
   union
   {
     struct {
-      uint8_t* data[4];      // [4] = alpha channel, currently not used
+      uint8_t* data[4];   // [4] = alpha channel, currently not used
       int iLineSize[4];   // [4] = alpha channel, currently not used
     };
     struct {
@@ -114,23 +112,23 @@ struct DVDVideoPicture
 
   double       iRepeatPicture;
   double       iDuration;
-  unsigned int iFrameType         : 4; // see defines above // 1->I, 2->P, 3->B, 0->Undef
+  unsigned int iFrameType         : 4;  //< see defines above // 1->I, 2->P, 3->B, 0->Undef
   unsigned int color_matrix       : 4;
-  unsigned int color_range        : 1; // 1 indicate if we have a full range of color
+  unsigned int color_range        : 1;  //< 1 indicate if we have a full range of color
   unsigned int chroma_position;
   unsigned int color_primaries;
   unsigned int color_transfer;
   unsigned int extended_format;
   char         stereo_mode[32];
 
-  int8_t* qp_table; // Quantization parameters, primarily used by filters
-  int qstride;
-  int qscale_type;
+  int8_t*      qp_table;                //< Quantization parameters, primarily used by filters
+  int          qstride;
+  int          qscale_type;
 
   unsigned int iWidth;
   unsigned int iHeight;
-  unsigned int iDisplayWidth;  // width of the picture without black bars
-  unsigned int iDisplayHeight; // height of the picture without black bars
+  unsigned int iDisplayWidth;           //< width of the picture without black bars
+  unsigned int iDisplayHeight;          //< height of the picture without black bars
 
   ERenderFormat format;
 };
@@ -142,16 +140,16 @@ struct DVDVideoUserData
 };
 
 #define DVP_FLAG_TOP_FIELD_FIRST    0x00000001
-#define DVP_FLAG_REPEAT_TOP_FIELD   0x00000002 //Set to indicate that the top field should be repeated
-#define DVP_FLAG_ALLOCATED          0x00000004 //Set to indicate that this has allocated data
-#define DVP_FLAG_INTERLACED         0x00000008 //Set to indicate that this frame is interlaced
+#define DVP_FLAG_REPEAT_TOP_FIELD   0x00000002  //< Set to indicate that the top field should be repeated
+#define DVP_FLAG_ALLOCATED          0x00000004  //< Set to indicate that this has allocated data
+#define DVP_FLAG_INTERLACED         0x00000008  //< Set to indicate that this frame is interlaced
 
-#define DVP_FLAG_NOSKIP             0x00000010 // indicate this picture should never be dropped
-#define DVP_FLAG_DROPPED            0x00000020 // indicate that this picture has been dropped in decoder stage, will have no data
+#define DVP_FLAG_NOSKIP             0x00000010  //< indicate this picture should never be dropped
+#define DVP_FLAG_DROPPED            0x00000020  //< indicate that this picture has been dropped in decoder stage, will have no data
 
-#define DVD_CODEC_CTRL_SKIPDEINT    0x01000000 // indicate that this picture was requested to have been dropped in deint stage
-#define DVD_CODEC_CTRL_NO_POSTPROC  0x02000000 // see GetCodecStats
-#define DVD_CODEC_CTRL_DRAIN        0x04000000 // see GetCodecStats
+#define DVD_CODEC_CTRL_SKIPDEINT    0x01000000  //< indicate that this picture was requested to have been dropped in deint stage
+#define DVD_CODEC_CTRL_NO_POSTPROC  0x02000000  //< see GetCodecStats
+#define DVD_CODEC_CTRL_DRAIN        0x04000000  //< see GetCodecStats
 
 // DVP_FLAG 0x00000100 - 0x00000f00 is in use by libmpeg2!
 
@@ -165,62 +163,60 @@ class CDVDCodecOption;
 class CDVDCodecOptions;
 
 // VC_ messages, messages can be combined
-#define VC_ERROR    0x00000001  // an error occured, no other messages will be returned
-#define VC_BUFFER   0x00000002  // the decoder needs more data
-#define VC_PICTURE  0x00000004  // the decoder got a picture, call Decode(NULL, 0) again to parse the rest of the data
-#define VC_USERDATA 0x00000008  // the decoder found some userdata,  call Decode(NULL, 0) again to parse the rest of the data
-#define VC_FLUSHED  0x00000010  // the decoder lost it's state, we need to restart decoding again
-#define VC_DROPPED  0x00000020  // needed to identify if a picture was dropped
-#define VC_NOBUFFER 0x00000040  // last FFmpeg GetBuffer failed
-#define VC_REOPEN   0x00000080  // decoder request to re-open
+#define VC_ERROR                    0x00000001  //< an error occured, no other messages will be returned
+#define VC_BUFFER                   0x00000002  //< the decoder needs more data
+#define VC_PICTURE                  0x00000004  //< the decoder got a picture, call Decode(NULL, 0) again to parse the rest of the data
+#define VC_USERDATA                 0x00000008  //< the decoder found some userdata,  call Decode(NULL, 0) again to parse the rest of the data
+#define VC_FLUSHED                  0x00000010  //< the decoder lost it's state, we need to restart decoding again
+#define VC_DROPPED                  0x00000020  //< needed to identify if a picture was dropped
+#define VC_NOBUFFER                 0x00000040  //< last FFmpeg GetBuffer failed
+#define VC_REOPEN                   0x00000080  //< decoder request to re-open
 
 class CDVDVideoCodec
 {
 public:
-
   CDVDVideoCodec() {}
   virtual ~CDVDVideoCodec() {}
 
-  /*
+  /**
    * Open the decoder, returns true on success
    */
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
 
-  /*
+  /**
    * Dispose, Free all resources
    */
   virtual void Dispose() = 0;
 
-  /*
+  /**
    * returns one or a combination of VC_ messages
    * pData and iSize can be NULL, this means we should flush the rest of the data.
    */
   virtual int Decode(uint8_t* pData, int iSize, double dts, double pts) = 0;
 
- /*
+  /**
    * Reset the decoder.
    * Should be the same as calling Dispose and Open after each other
    */
   virtual void Reset() = 0;
 
-  /*
+  /**
    * returns true if successfull
    * the data is valid until the next Decode call
    */
   virtual bool GetPicture(DVDVideoPicture* pDvdVideoPicture) = 0;
 
-
-  /*
+  /**
    * returns true if successfull
    * the data is cleared to zero
-   */ 
+   */
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture)
   {
     memset(pDvdVideoPicture, 0, sizeof(DVDVideoPicture));
     return true;
   }
 
-  /*
+  /**
    * returns true if successfull
    * the data is valid until the next Decode call
    * userdata can be anything, for now we use it for closed captioning
@@ -232,13 +228,13 @@ public:
     return false;
   }
 
-  /*
+  /**
    * will be called by video player indicating if a frame will eventually be dropped
    * codec can then skip actually decoding the data, just consume the data set picture headers
    */
   virtual void SetDropState(bool bDrop) = 0;
 
-  /*
+  /**
    * will be called by video player indicating the playback speed. see DVD_PLAYSPEED_NORMAL,
    * DVD_PLAYSPEED_PAUSE and friends.
    */
@@ -246,29 +242,26 @@ public:
 
   enum EFilterFlags {
     FILTER_NONE                =  0x0,
-    FILTER_DEINTERLACE_YADIF   =  0x1,  /* use first deinterlace mode */
-    FILTER_DEINTERLACE_ANY     =  0xf,  /* use any deinterlace mode */
-    FILTER_DEINTERLACE_FLAGGED = 0x10,  /* only deinterlace flagged frames */
-    FILTER_DEINTERLACE_HALFED  = 0x20,  /* do half rate deinterlacing */
-    FILTER_ROTATE              = 0x40,  /* rotate image according to the codec hints */
+    FILTER_DEINTERLACE_YADIF   =  0x1,  //< use first deinterlace mode
+    FILTER_DEINTERLACE_ANY     =  0xf,  //< use any deinterlace mode
+    FILTER_DEINTERLACE_FLAGGED = 0x10,  //< only deinterlace flagged frames
+    FILTER_DEINTERLACE_HALFED  = 0x20,  //< do half rate deinterlacing
+    FILTER_ROTATE              = 0x40,  //< rotate image according to the codec hints
   };
 
-  /*
+  /**
    * set the type of filters that should be applied at decoding stage if possible
    */
-  virtual unsigned int SetFilters(unsigned int filters) { return 0u; }
+  virtual unsigned int SetFilters(unsigned int filters) { return 0; }
 
-  /*
-   *
+  /**
    * should return codecs name
    */
   virtual const char* GetName() = 0;
 
-  /*
-   *
-   * How many packets should player remember, so codec
-   * can recover should something cause it to flush
-   * outside of players control
+  /**
+   * How many packets should player remember, so codec can recover should
+   * something cause it to flush outside of players control
    */
   virtual unsigned GetConvergeCount()
   {
@@ -276,24 +269,23 @@ public:
   }
 
   /**
-   * Number of references to old pictures that are allowed to
-   * be retained when calling decode on the next demux packet
+   * Number of references to old pictures that are allowed to be retained when
+   * calling decode on the next demux packet
    */
   virtual unsigned GetAllowedReferences() { return 0; }
 
   /**
-   * Hide or Show Settings depending on the currently running hardware 
-   *
+   * Hide or Show Settings depending on the currently running hardware
    */
-   static bool IsSettingVisible(const std::string &condition, const std::string &value, const CSetting *setting, void *data);
+  static bool IsSettingVisible(const std::string &condition, const std::string &value, const CSetting *setting, void *data);
 
   /**
-  * Interact with user settings so that user disabled codecs are disabled
-  */
+   * Interact with user settings so that user disabled codecs are disabled
+   */
   static bool IsCodecDisabled(DVDCodecAvailableType* map, unsigned int size, AVCodecID id);
 
-   /* For calculation of dropping requirements player asks for some information.
-   *
+  /**
+   * For calculation of dropping requirements player asks for some information.
    * - pts : right after decoder, used to detect gaps (dropped frames in decoder)
    * - droppedPics : indicates if decoder has dropped a picture
    *                 -1 means that decoder has no info on this.
@@ -304,7 +296,7 @@ public:
    */
   virtual bool GetCodecStats(double &pts, int &droppedPics)
   {
-    droppedPics= -1;
+    droppedPics = -1;
     return false;
   }
 
@@ -325,9 +317,9 @@ public:
    */
   virtual void SetCodecControl(int flags) {}
 
-  /*
-    * Re-open the decoder.
-    * Decoder request to re-open
-    */
-   virtual void Reopen() {};
+  /**
+   * Re-open the decoder.
+   * Decoder request to re-open
+   */
+  virtual void Reopen() {};
 };


### PR DESCRIPTION
The included change add the support for build with ./tools/buildsteps/* and ./tools/depends/target/* used from jenkins (I think jenkins itself still have not this libs).

Is tested here with Ubuntu vivid 64bit and was possible to build, run and play with standard package from http://packages.ubuntu.com/vivid/libegl1-mesa-dev. Without them from https://launchpad.net/~wsnipex/+archive/ubuntu/mesa/+packages :D .

What need to check on end is libxcb-dri2. Not sure that on end two independent libs are needed, I think no, currently yes. <b>EDIT:</b> Seen also on "wily" required.
The other to check is libGLEW on Mac OS X, think is maybe not required anymore.

Further has I added the temporary TODO strings in the Makefile, hope is OK. Still in development ;)

For the Makefile I has separated the files to linux-system-libs-egl for a better overview.

