### PR TITLE
Improve visualization API

### DIFF
--- a/addons/library.kodi.guilib/libKODI_guilib.h
+++ b/addons/library.kodi.guilib/libKODI_guilib.h
@@ -825,13 +825,13 @@ public:
   virtual ~CAddonGUIRenderingControl();
   virtual void Init();
 
-  virtual bool Create(int x, int y, int w, int h, void *device);
+  virtual bool Create(int x, int y, int w, int h, float ratio);
   virtual void Render();
   virtual void Stop();
   virtual bool Dirty();
 
   GUIHANDLE m_cbhdl;
-  bool (*CBCreate)(GUIHANDLE cbhdl, int x, int y, int w, int h, void *device);
+  bool (*CBCreate)(GUIHANDLE cbhdl, int x, int y, int w, int h, float ratio);
   void (*CBRender)(GUIHANDLE cbhdl);
   void (*CBStop)(GUIHANDLE cbhdl);
   bool (*CBDirty)(GUIHANDLE cbhdl);

--- a/lib/addons/library.kodi.guilib/libKODI_guilib.cpp
+++ b/lib/addons/library.kodi.guilib/libKODI_guilib.cpp
@@ -932,10 +932,10 @@ DLLEXPORT void GUI_control_release_rendering(CAddonGUIRenderingControl* p)
   delete p;
 }
 
-DLLEXPORT bool GUI_control_rendering_create(GUIHANDLE handle, int x, int y, int w, int h, void *device)
+DLLEXPORT bool GUI_control_rendering_create(GUIHANDLE handle, int x, int y, int w, int h, float ratio)
 {
   CAddonGUIRenderingControl *pControl = (CAddonGUIRenderingControl*) handle;
-  return pControl->Create(x,y,w,h,device);
+  return pControl->Create(x,y,w,h,ratio);
 }
 
 DLLEXPORT void GUI_control_rendering_render(GUIHANDLE handle)
@@ -975,12 +975,12 @@ void CAddonGUIRenderingControl::Init()
   ((CB_GUILib*)m_cb)->RenderAddon_SetCallbacks(((AddonCB*)m_Handle)->addonData, m_RenderingHandle, this, GUI_control_rendering_create, GUI_control_rendering_render, GUI_control_rendering_stop, GUI_control_rendering_dirty);
 }
 
-bool CAddonGUIRenderingControl::Create(int x, int y, int w, int h, void *device)
+bool CAddonGUIRenderingControl::Create(int x, int y, int w, int h, float ratio)
 {
   if (!CBCreate)
     return false;
 
-  return CBCreate(m_cbhdl, x, y, w, h, device);
+  return CBCreate(m_cbhdl, x, y, w, h, ratio);
 }
 
 void CAddonGUIRenderingControl::Render()

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -168,6 +168,7 @@
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
 #include "addons/RepositoryUpdater.h"
+#include "addons/Visualisation.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "CompileInfo.h"
@@ -4679,6 +4680,8 @@ void CApplication::ProcessSlow()
 #ifdef HAS_FILESYSTEM_SFTP
   CSFTPSessionManager::ClearOutIdleSessions();
 #endif
+
+  CVisualisationManager::GetInstance().ClearOutIdle();
 
   g_mediaManager.ProcessEvents();
 

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -195,7 +195,7 @@ typedef void        (*GUIListItem_SetInfo)(void *addonData, GUIHANDLE handle, co
 typedef void        (*GUIListItem_SetProperty)(void *addonData, GUIHANDLE handle, const char *key, const char *value);
 typedef const char* (*GUIListItem_GetProperty)(void *addonData, GUIHANDLE handle, const char *key);
 typedef void        (*GUIListItem_SetPath)(void *addonData, GUIHANDLE handle, const char *path);
-typedef void        (*GUIRenderAddon_SetCallbacks)(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,void*), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE));
+typedef void        (*GUIRenderAddon_SetCallbacks)(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,float), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE));
 typedef void        (*GUIRenderAddon_Delete)(void *addonData, GUIHANDLE handle);
 typedef void        (*GUIRenderAddon_MarkDirty)(void *addonData, GUIHANDLE handle);
 

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1632,7 +1632,7 @@ void CAddonCallbacksGUI::ListItem_SetPath(void *addonData, GUIHANDLE handle, con
   ((CFileItem*)handle)->SetPath(path);
 }
 
-void CAddonCallbacksGUI::RenderAddon_SetCallbacks(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,void*), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE))
+void CAddonCallbacksGUI::RenderAddon_SetCallbacks(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,float), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE))
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper || !handle)
@@ -2236,11 +2236,11 @@ CGUIAddonRenderingControl::CGUIAddonRenderingControl(CGUIRenderingControl *pCont
   m_refCount{1}
 { }
 
-bool CGUIAddonRenderingControl::Create(int x, int y, int w, int h, void *device)
+bool CGUIAddonRenderingControl::Create(int x, int y, int w, int h, float ratio)
 {
   if (CBCreate)
   {
-    if (CBCreate(m_clientHandle, x, y, w, h, device))
+    if (CBCreate(m_clientHandle, x, y, w, h, ratio))
     {
       m_refCount++;
       return true;

--- a/xbmc/addons/AddonCallbacksGUI.h
+++ b/xbmc/addons/AddonCallbacksGUI.h
@@ -141,7 +141,7 @@ public:
   static void         ListItem_SetProperty(void *addonData, GUIHANDLE handle, const char *key, const char *value);
   static const char * ListItem_GetProperty(void *addonData, GUIHANDLE handle, const char *key);
   static void         ListItem_SetPath(void *addonData, GUIHANDLE handle, const char *path);
-  static void         RenderAddon_SetCallbacks(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,void*), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE));
+  static void         RenderAddon_SetCallbacks(void *addonData, GUIHANDLE handle, GUIHANDLE clienthandle, bool (*createCB)(GUIHANDLE,int,int,int,int,float), void (*renderCB)(GUIHANDLE), void (*stopCB)(GUIHANDLE), bool (*dirtyCB)(GUIHANDLE));
   static void         RenderAddon_Delete(void *addonData, GUIHANDLE handle);
   static void         RenderAddon_MarkDirty(void *addonData, GUIHANDLE handle);
 
@@ -253,13 +253,13 @@ friend class CAddonCallbacksGUI;
 public:
   CGUIAddonRenderingControl(CGUIRenderingControl *pControl);
   virtual ~CGUIAddonRenderingControl() {}
-  virtual bool Create(int x, int y, int w, int h, void *device);
+  virtual bool Create(int x, int y, int w, int h, float ratio);
   virtual void Render();
   virtual void Stop();
   virtual bool IsDirty();
   virtual void Delete();
 protected:
-  bool (*CBCreate) (GUIHANDLE cbhdl, int x, int y, int w, int h, void *device);
+  bool (*CBCreate) (GUIHANDLE cbhdl, int x, int y, int w, int h, float ratio);
   void (*CBRender)(GUIHANDLE cbhdl);
   void (*CBStop)(GUIHANDLE cbhdl);
   bool (*CBDirty)(GUIHANDLE cbhdl);

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -169,7 +169,7 @@ void CVisualisation::Render()
 
 void CVisualisation::Stop()
 {
-  CAEFactory::UnregisterAudioCallback();
+  CAEFactory::UnregisterAudioCallback(this);
   if (Initialized())
   {
     CAddonDll<DllVisualisation, Visualisation, VIS_PROPS>::Stop();

--- a/xbmc/addons/include/xbmc_vis_dll.h
+++ b/xbmc/addons/include/xbmc_vis_dll.h
@@ -27,7 +27,8 @@
 extern "C"
 {
   // Functions that your visualisation must implement
-  void Start(int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
+  void Start(int x, int y, int width, int height, float pixelRatio,
+             int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
   void AudioData(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength);
   void Render();
   bool OnAction(long action, const void *param);

--- a/xbmc/addons/include/xbmc_vis_types.h
+++ b/xbmc/addons/include/xbmc_vis_types.h
@@ -37,11 +37,6 @@ extern "C"
   struct VIS_PROPS
   {
     void *device;
-    int x;
-    int y;
-    int width;
-    int height;
-    float pixelRatio;
     const char *name;
     const char *presets;
     const char *profile;
@@ -95,7 +90,9 @@ extern "C"
 
   struct Visualisation
   {
-    void (__cdecl* Start)(int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
+    void (__cdecl* Start)(int x, int y, int width, int height, float pixelRatio,
+                          int iChannels, int iSamplesPerSec, int iBitsPerSample,
+                          const char* szSongName);
     void (__cdecl* AudioData)(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength);
     void (__cdecl* Render) ();
     void (__cdecl* GetInfo)(VIS_INFO *info);

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -372,10 +372,10 @@ void CAEFactory::RegisterAudioCallback(IAudioCallback* pCallback)
     AE->RegisterAudioCallback(pCallback);
 }
 
-void CAEFactory::UnregisterAudioCallback()
+void CAEFactory::UnregisterAudioCallback(IAudioCallback* pCallback)
 {
   if (AE)
-    AE->UnregisterAudioCallback();
+    AE->UnregisterAudioCallback(pCallback);
 }
 
 bool CAEFactory::IsSettingVisible(const std::string &condition, const std::string &value, const CSetting *setting, void *data)

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -72,7 +72,7 @@ public:
   static void DeviceChange();
 
   static void RegisterAudioCallback(IAudioCallback* pCallback);
-  static void UnregisterAudioCallback();
+  static void UnregisterAudioCallback(IAudioCallback* pCallback);
 
 private:
   static IAE *AE;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -227,7 +227,6 @@ CActiveAE::CActiveAE() :
   m_aeMuted = false;
   m_mode = MODE_PCM;
   m_encoder = NULL;
-  m_audioCallback = NULL;
   m_vizInitialized = false;
   m_sinkHasVolume = false;
   m_aeGUISoundForce = false;
@@ -1249,7 +1248,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         m_discardBufferPools.push_back(m_vizBuffersInput);
         m_vizBuffersInput = NULL;
       }
-      if (!m_vizBuffers && m_audioCallback)
+      if (!m_vizBuffers && !m_audioCallback.empty())
       {
         AEAudioFormat vizFormat = m_internalFormat;
         vizFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
@@ -2099,12 +2098,13 @@ bool CActiveAE::RunStages()
         // viz
         {
           CSingleLock lock(m_vizLock);
-          if (m_audioCallback && !m_streams.empty())
+          if (!m_audioCallback.empty() && !m_streams.empty())
           {
             if (!m_vizInitialized || !m_vizBuffers)
             {
               Configure();
-              m_audioCallback->OnInitialize(2, m_vizBuffers->m_format.m_sampleRate, 32);
+              for (auto& it : m_audioCallback)
+                it->OnInitialize(2, m_vizBuffers->m_format.m_sampleRate, 32);
               m_vizInitialized = true;
             }
 
@@ -2136,7 +2136,8 @@ bool CActiveAE::RunStages()
               else
               {
                 int samples = buf->pkt->nb_samples;
-                m_audioCallback->OnAudioData((float*)(buf->pkt->data[0]), samples);
+                for (auto& it : m_audioCallback)
+                  it->OnAudioData((float*)(buf->pkt->data[0]), samples);
                 buf->Return();
                 m_vizBuffers->m_outputSamples.pop_front();
               }
@@ -3186,12 +3187,14 @@ void CActiveAE::SetStreamFade(CActiveAEStream *stream, float from, float target,
 void CActiveAE::RegisterAudioCallback(IAudioCallback* pCallback)
 {
   CSingleLock lock(m_vizLock);
-  m_audioCallback = pCallback;
+  m_audioCallback.push_back(pCallback);
   m_vizInitialized = false;
 }
 
-void CActiveAE::UnregisterAudioCallback()
+void CActiveAE::UnregisterAudioCallback(IAudioCallback* pCallback)
 {
   CSingleLock lock(m_vizLock);
-  m_audioCallback = NULL;
+  auto it = std::find(m_audioCallback.begin(), m_audioCallback.end(), pCallback);
+  if (it != m_audioCallback.end())
+    m_audioCallback.erase(it);
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -260,7 +260,7 @@ public:
   virtual AEAudioFormat GetCurrentSinkFormat();
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback);
-  virtual void UnregisterAudioCallback();
+  virtual void UnregisterAudioCallback(IAudioCallback* pCallback);
 
   virtual void OnLostDevice();
   virtual void OnResetDevice();
@@ -379,7 +379,7 @@ protected:
   bool m_sinkHasVolume;
 
   // viz
-  IAudioCallback *m_audioCallback;
+  std::vector<IAudioCallback*> m_audioCallback;
   bool m_vizInitialized;
   CCriticalSection m_vizLock;
 

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -227,7 +227,7 @@ public:
 
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) {}
 
-  virtual void UnregisterAudioCallback() {}
+  virtual void UnregisterAudioCallback(IAudioCallback* pCallback) {}
 
   /**
    * Returns true if AudioEngine supports specified quality level

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1473,7 +1473,13 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     }
     break;
   case CGUIControl::GUICONTROL_VISUALISATION:
-    control = new CGUIVisualisationControl(parentID, id, posX, posY, width, height);
+    {
+      int slot=0;
+      XMLUtils::GetInt(pControlNode, "slot", slot);
+      std::string aid;
+      XMLUtils::GetString(pControlNode, "id", aid);
+      control = new CGUIVisualisationControl(parentID, id, posX, posY, width, height, slot, aid);
+    }
     break;
   case CGUIControl::GUICONTROL_RENDERADDON:
     control = new CGUIRenderingControl(parentID, id, posX, posY, width, height);

--- a/xbmc/guilib/GUIRenderingControl.cpp
+++ b/xbmc/guilib/GUIRenderingControl.cpp
@@ -57,11 +57,8 @@ bool CGUIRenderingControl::InitCallback(IRenderingCallback *callback)
   if (x + w > g_graphicsContext.GetWidth()) w = g_graphicsContext.GetWidth() - x;
   if (y + h > g_graphicsContext.GetHeight()) h = g_graphicsContext.GetHeight() - y;
 
-  void *device = NULL;
-#if HAS_DX
-  device = g_Windowing.Get3D11Device();
-#endif
-  if (callback->Create((int)(x+0.5f), (int)(y+0.5f), (int)(w+0.5f), (int)(h+0.5f), device))
+  if (callback->Create((int)(x+0.5f), (int)(y+0.5f), (int)(w+0.5f), (int)(h+0.5f),
+                       g_graphicsContext.GetResInfo().fPixelRatio))
     m_callback = callback;
   else
     return false;

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -26,6 +26,7 @@
 #include "addons/Visualisation.h"
 #include "utils/log.h"
 #include "input/Key.h"
+#include "settings/Settings.h"
 
 using namespace ADDON;
 
@@ -33,8 +34,8 @@ using namespace ADDON;
 #define LABEL_ROW2 11
 #define LABEL_ROW3 12
 
-CGUIVisualisationControl::CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height)
-    : CGUIRenderingControl(parentID, controlID, posX, posY, width, height), m_bAttemptedLoad(false)
+CGUIVisualisationControl::CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height, int slot, const std::string& id)
+    : CGUIRenderingControl(parentID, controlID, posX, posY, width, height), m_bAttemptedLoad(false), m_slot(slot), m_id(id)
 {
   ControlType = GUICONTROL_VISUALISATION;
 }
@@ -99,8 +100,9 @@ void CGUIVisualisationControl::Process(unsigned int currentTime, CDirtyRegionLis
 
     if (!m_addon && !m_bAttemptedLoad)
     {
-      AddonPtr addon;
-      if (ADDON::CAddonMgr::GetInstance().GetDefault(ADDON_VIZ, addon))
+      std::string id = m_id.empty()?CSettings::GetInstance().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION):m_id;
+      AddonPtr addon = ADDON::CVisualisationManager::GetInstance().GetAddon(id, m_slot);
+      if (addon)
       {
         m_addon = std::dynamic_pointer_cast<CVisualisation>(addon);
         if (m_addon)
@@ -125,6 +127,8 @@ void CGUIVisualisationControl::FreeResources(bool immediately)
   g_windowManager.SendMessage(msg);
   CLog::Log(LOGDEBUG, "FreeVisualisation() started");
   CGUIRenderingControl::FreeResources(immediately);
+  m_addon->Stop();
+  CVisualisationManager::GetInstance().Release(m_slot);
   m_addon.reset();
   CLog::Log(LOGDEBUG, "FreeVisualisation() done");
 }

--- a/xbmc/guilib/GUIVisualisationControl.h
+++ b/xbmc/guilib/GUIVisualisationControl.h
@@ -25,7 +25,7 @@
 class CGUIVisualisationControl : public CGUIRenderingControl
 {
 public:
-  CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height);
+  CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height, int slot, const std::string& id);
   CGUIVisualisationControl(const CGUIVisualisationControl &from);
   virtual CGUIVisualisationControl *Clone() const { return new CGUIVisualisationControl(*this); }; //TODO check for naughties
   virtual void FreeResources(bool immediately = false);
@@ -35,4 +35,6 @@ public:
 private:
   bool m_bAttemptedLoad;
   ADDON::VizPtr m_addon;
+  int m_slot;
+  std::string m_id;
 };

--- a/xbmc/guilib/IRenderingCallback.h
+++ b/xbmc/guilib/IRenderingCallback.h
@@ -23,7 +23,7 @@
 class IRenderingCallback
 {
 public:
-  virtual bool Create(int x, int y, int w, int h, void *device) = 0;
+  virtual bool Create(int x, int y, int w, int h, float pixelRatio) = 0;
   virtual void Render() = 0;
   virtual void Stop() = 0;
   virtual bool IsDirty() { return true; }


### PR DESCRIPTION
  - introduce a manager for instances of visualisation addons
 - use this to detach a visualisation's lifecycle from a visualisation
      gui control's life cycle
 - introduce multiple slots for visualization - allowing multiple
      displayed at the same time. this is exposed to skinners through the
      subtags 'slot' (just some number) and 'id' (the add-on id for the
      visualization).    

-  add-ons needs to be updated, as the API changes. we have to change the Start()
    method to pass screen info since this is now called once per gui control
    instance. Likewise Stop() is called when the gui control is killed.

-   Create() is called at the beginning of the life cycle, and Create()
    at the end. These are called exactly once.

Right now the only add-on I have updated is https://github.com/notspiff/visualization.vsxu
I chose that one on purpose because it shows the value of this change very clearly.