### PR TITLE
[iMX6] fix compilation and rendering

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererIMX.cpp
@@ -57,7 +57,6 @@ void CRendererIMX::AddVideoPictureHW(DVDVideoPicture &picture, int index)
   YUVBUFFER &buf = m_buffers[index];
   CDVDVideoCodecIMXBuffer *buffer = static_cast<CDVDVideoCodecIMXBuffer*>(buf.hwDec);
 
-  SAFE_RELEASE(buffer);
   buf.hwDec = picture.IMXBuffer;
 
   if (picture.IMXBuffer)
@@ -68,6 +67,7 @@ void CRendererIMX::ReleaseBuffer(int idx)
 {
   CDVDVideoCodecIMXBuffer *buffer =  static_cast<CDVDVideoCodecIMXBuffer*>(m_buffers[idx].hwDec);
   SAFE_RELEASE(buffer);
+  m_buffers[idx].hwDec = NULL;
 }
 
 int CRendererIMX::GetImageHook(YV12Image *image, int source, bool readonly)
@@ -223,6 +223,12 @@ bool CRendererIMX::CreateTexture(int index)
   YUVFIELDS &fields = m_buffers[index].fields;
   YUVPLANE  &plane  = fields[0][0];
 
+  /* Lock buffer to maintain proper ref count */
+  YUVBUFFER &buf = m_buffers[index];
+  CDVDVideoCodecIMXBuffer* buffer = static_cast<CDVDVideoCodecIMXBuffer*>(buf.hwDec);
+  if (buffer)
+    buffer->Lock();
+
   DeleteTexture(index);
 
   memset(&im    , 0, sizeof(im));
@@ -266,5 +272,5 @@ bool CRendererIMX::UploadTexture(int index)
 {
   return true;// nothing todo for IMX
 }
-
 #endif
+

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -52,7 +52,7 @@
 #include "HWDecRender/RendererVTB.h"
 #endif
 #if defined(HAS_IMXVPU)
-#include "HWDecRender/RendererIMX.h"
+#include "HwDecRender/RendererIMX.h"
 #endif
 #if defined(HAVE_LIBOPENMAX)
 #include "HWDecRender/RendererOMX.h"


### PR DESCRIPTION
This PR fixes compilation and rendering for iMX6 target following PR https://github.com/FernetMenta/xbmc/pull/285 
imx hw buffers are ref counted and I have carefully checked that this PR restores proper behavior by monitoring this lock counter.
Now this seems fine but obviously wider testing would be welcome...

As a side note for imx6 users/packagers, in my env, I also had to revert commit https://github.com/wolfgar/xbmc/commit/bbbb46947b5306278b1f4375908f5a5395d6d073 otherwise I am quickly hit by the following glibc assertion error about lock :
```
pthread_mutex_lock.c:348: __pthread_mutex_lock_full: Assertion `(-(e)) != 35 || (kind != PTHREAD_MUTEX_ERRORCHECK_NP && kind != PTHREAD_MUTEX_RECURSIVE_NP)' failed
```
Obviously it is not kodi code which is bad here but there is likely an issue in imx kernel and/or glibc which is responsible for this issue...
