### PR TITLE
cmake updates

### DIFF
--- a/project/cmake/modules/FindCpluff.cmake
+++ b/project/cmake/modules/FindCpluff.cmake
@@ -3,6 +3,7 @@ get_filename_component(expat_dir ${EXPAT_LIBRARY} PATH)
 set(ldflags "-L${expat_dir}")
 ExternalProject_ADD(libcpluff SOURCE_DIR ${CORE_SOURCE_DIR}/lib/cpluff
                     PREFIX ${CORE_BUILD_DIR}/cpluff
+                    PATCH_COMMAND rm -f config.status
                     UPDATE_COMMAND autoreconf -vif
                     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} ${CORE_SOURCE_DIR}/lib/cpluff/configure
                                       --disable-nls

--- a/project/cmake/modules/FindLibDvd.cmake
+++ b/project/cmake/modules/FindLibDvd.cmake
@@ -5,6 +5,7 @@ endif()
 if(ENABLE_DVDCSS)
   ExternalProject_ADD(dvdcss SOURCE_DIR ${CORE_SOURCE_DIR}/lib/libdvd/libdvdcss/
                              PREFIX ${CORE_BUILD_DIR}/libdvd
+                      PATCH_COMMAND rm -f config.status
                       UPDATE_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND  <SOURCE_DIR>/configure
                                         --target=${ARCH}
@@ -29,6 +30,7 @@ endif(ENABLE_DVDCSS)
 
 ExternalProject_ADD(dvdread SOURCE_DIR ${CORE_SOURCE_DIR}/lib/libdvd/libdvdread/
                             PREFIX ${CORE_BUILD_DIR}/libdvd
+                    PATCH_COMMAND rm -f config.status
                     UPDATE_COMMAND autoreconf -vif
                     CONFIGURE_COMMAND <SOURCE_DIR>/configure
                                       --target=${ARCH}
@@ -49,6 +51,7 @@ core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/libdvd/lib/libdvdread.a
 
 ExternalProject_ADD(dvdnav SOURCE_DIR ${CORE_SOURCE_DIR}/lib/libdvd/libdvdnav/
                            PREFIX ${CORE_BUILD_DIR}/libdvd
+                    PATCH_COMMAND rm -f config.status
                     UPDATE_COMMAND autoreconf -vif
                     CONFIGURE_COMMAND <SOURCE_DIR>/configure
                                       --target=${ARCH}

--- a/project/cmake/treedata/linux/subdirs.txt
+++ b/project/cmake/treedata/linux/subdirs.txt
@@ -1,5 +1,7 @@
 xbmc/linux                 linuxsupport
 xbmc/input/linux           input/linux
+xbmc/input/touch           input/touch
+xbmc/input/touch/generic   input/touch/generic
 xbmc/network/linux         network/linux
 xbmc/peripherals/bus/linux peripherals/bus/linux
 xbmc/powermanagement/linux powermanagement/linux

--- a/project/cmake/treedata/rbpi/subdirs.txt
+++ b/project/cmake/treedata/rbpi/subdirs.txt
@@ -1,5 +1,7 @@
 xbmc/linux                 linuxsupport
 xbmc/input/linux           input/linux
+xbmc/input/touch           input/touch
+xbmc/input/touch/generic   input/touch/generic
 xbmc/network/linux         network/linux
 xbmc/peripherals/bus/linux peripherals/bus/linux
 xbmc/powermanagement/linux powermanagement/linux

--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -1,3 +1,6 @@
+enable_language(CXX ASM)
+set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp" )
+
 set(SOURCES BaseRenderer.cpp
             OverlayRenderer.cpp
             OverlayRendererGUI.cpp
@@ -21,6 +24,11 @@ if(GLES_FOUND)
                       OverlayRendererGL.cpp)
 
 endif()
+
+if(ARCH MATCHES "arm")
+  list(APPEND SOURCES yuv2rgb.neon.S)
+endif()
+
 
 core_add_library(videorenderers)
 add_dependencies(videorenderers ffmpeg)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/yuv2rgb.neon.S
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/yuv2rgb.neon.S
@@ -7,7 +7,7 @@
 //
 //
 //
-#ifdef __ARM_NEON__
+#if defined __ARM_NEON__ || defined(__ARM_NEON__)
 
  /* Initial ARM Neon implementation of core YUV2RGB functions. */
         
@@ -490,5 +490,6 @@ loop_h_422:
 #ifndef __APPLE__
         .fnend
 #endif
-
+#else
+#error __ARM_NEON__ not defined
 #endif /* __ARM_NEON__ */

--- a/xbmc/input/CMakeLists.txt
+++ b/xbmc/input/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES ButtonTranslator.cpp
             InputCodingTableBaiduPY.cpp
             InputCodingTableBasePY.cpp
             InputCodingTableFactory.cpp
+            InputCodingTableKorean.cpp
             InputManager.cpp
             Key.cpp
             KeyboardLayout.cpp

--- a/xbmc/input/touch/CMakeLists.txt
+++ b/xbmc/input/touch/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES ITouchInputHandling.cpp)
+
+core_add_library(input_touch)

--- a/xbmc/input/touch/generic/CMakeLists.txt
+++ b/xbmc/input/touch/generic/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES GenericTouchActionHandler.cpp
+            GenericTouchInputHandler.cpp
+            GenericTouchPinchDetector.cpp
+            GenericTouchRotateDetector.cpp
+            GenericTouchSwipeDetector.cpp)
+
+core_add_library(input_touch_generic)


### PR DESCRIPTION
this syncs cmake and should hopefully fix the issues @popcornmix has with building on rpi in https://github.com/FernetMenta/xbmc/pull/298

Since building OMXplayer is broken after the recent audio sync changes, I've added a hackjob to make it _build_ again. I've almost certainly broken something, but videoplayer/omxplayer internals are above my paygrade ;) Maybe it can serve as a starting point for popcornmix or someone else to properly sync up with the recent changes.