### PR TITLE
yuv2rgb: don't error on non neon devices - squash to b5e3cc4b

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -283,6 +283,10 @@ DemuxPacket* CDVDDemuxPVRClient::Read()
     return NULL;
   }
 
+  // TODO query client
+  if (m_pInput)
+    m_pInput->SetRealtime(true);
+
   if (pPacket->iStreamId == DMX_SPECIALID_STREAMINFO)
   {
     RequestStreams();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -25,6 +25,7 @@ CDVDInputStream::CDVDInputStream(DVDStreamType streamType)
 {
   m_streamType = streamType;
   m_contentLookup = true;
+  m_realtime = false;
 }
 
 CDVDInputStream::~CDVDInputStream()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -182,6 +182,10 @@ public:
 
   bool ContentLookup() { return m_contentLookup; }
 
+  bool IsRealtime() { return m_realtime; }
+
+  void SetRealtime(bool realtime) { m_realtime = realtime; }
+
 protected:
   DVDStreamType m_streamType;
   std::string m_strFileName;
@@ -190,4 +194,5 @@ protected:
   std::string m_content;
   CFileItem m_item;
   bool m_contentLookup;
+  bool m_realtime;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1795,7 +1795,7 @@ void CVideoPlayer::HandlePlaySpeed()
       // take action is audio or video stream is stalled
       if (m_VideoPlayerAudio->IsStalled() || m_VideoPlayerVideo->IsStalled())
       {
-        if (CachePVRStream())
+        if (m_pInputStream->IsRealtime())
         {
           if ((m_CurrentAudio.syncState == IDVDStreamPlayer::SYNC_INSYNC && m_VideoPlayerAudio->GetLevel() == 0) ||
               (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_INSYNC && m_VideoPlayerVideo->GetLevel() == 0))
@@ -1823,7 +1823,7 @@ void CVideoPlayer::HandlePlaySpeed()
         }
       }
       // care for live streams
-      else if (CachePVRStream())
+      else if (m_pInputStream->IsRealtime())
       {
         if (m_CurrentAudio.id >= 0)
         {
@@ -1867,7 +1867,7 @@ void CVideoPlayer::HandlePlaySpeed()
 
       if (m_CurrentAudio.starttime != DVD_NOPTS_VALUE)
       {
-        if (CachePVRStream())
+        if (m_pInputStream->IsRealtime())
           clock = m_CurrentAudio.starttime - m_CurrentAudio.cachetotal - DVD_MSEC_TO_TIME(200);
         else
           clock = m_CurrentAudio.starttime - m_CurrentAudio.cachetime;
@@ -2748,8 +2748,7 @@ void CVideoPlayer::SetCaching(ECacheState state)
     m_VideoPlayerAudio->SetSpeed(DVD_PLAYSPEED_PAUSE);
     m_VideoPlayerVideo->SetSpeed(DVD_PLAYSPEED_PAUSE);
 
-    if (CachePVRStream())
-      m_pInputStream->ResetScanTimeout((unsigned int) CSettings::GetInstance().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
+    m_pInputStream->ResetScanTimeout((unsigned int) CSettings::GetInstance().GetInt(CSettings::SETTING_PVRPLAYBACK_SCANTIME) * 1000);
   }
 
   if(state == CACHESTATE_PLAY
@@ -4680,12 +4679,6 @@ bool CVideoPlayer::SwitchChannel(const CPVRChannelPtr &channel)
   m_messenger.Put(new CDVDMsgType<CPVRChannelPtr>(CDVDMsg::PLAYER_CHANNEL_SELECT, channel));
 
   return true;
-}
-
-bool CVideoPlayer::CachePVRStream(void) const
-{
-  return m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) &&
-         !g_PVRManager.IsPlayingRecording();
 }
 
 void CVideoPlayer::FrameMove()

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -291,7 +291,6 @@ public:
   virtual std::string GetPlayingTitle();
 
   virtual bool SwitchChannel(const PVR::CPVRChannelPtr &channel);
-  virtual bool CachePVRStream(void) const;
 
   virtual void FrameMove();
   virtual void FrameWait(int ms);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/yuv2rgb.neon.S
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/yuv2rgb.neon.S
@@ -490,6 +490,4 @@ loop_h_422:
 #ifndef __APPLE__
         .fnend
 #endif
-#else
-#error __ARM_NEON__ not defined
 #endif /* __ARM_NEON__ */


### PR DESCRIPTION
forgot to remove this debugging code before the last PR.
fixes building on pi1