### PR TITLE
VAAPI: squash me to aa90e792380192c3ca3d766b0cf9e357f98a663c

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -910,7 +910,7 @@ int CDecoder::Check(AVCodecContext* avctx)
       return VC_ERROR;
   }
 
-  if (m_getBufferError >= 0 && m_getBufferError < 5)
+  if (m_getBufferError > 0 && m_getBufferError < 5)
   {
     // if there is no other error, sleep for a short while
     // in order not to drain player's message queue


### PR DESCRIPTION
This would stall the decoder _always_ as the condition was always true.