### PR TITLE
Egl refactoring

### DIFF
--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -61,6 +61,7 @@ public:
   virtual bool IsExtSupported(const char* extension);
 
   virtual void SetVSync(bool vsync);
+  virtual void ResetVSync() { m_bVsyncInit = false; }
 
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -164,7 +164,6 @@
 #endif
 #define HAS_GL
 #ifdef HAVE_X11
-#define HAS_GLX
 #define HAS_X11_WIN_EVENTS
 #endif
 #ifdef HAVE_SDL
@@ -191,6 +190,13 @@
 
 #ifdef HAVE_LIBSSH
 #define HAS_FILESYSTEM_SFTP
+#endif
+
+#if defined(HAVE_X11)
+#define HAS_EGL
+#if !defined(HAVE_LIBGLESV2)
+#define HAS_GLX
+#endif
 #endif
 
 /****************************************
@@ -232,12 +238,6 @@
 #if defined(TARGET_ANDROID)
 #undef HAS_LINUX_EVENTS
 #undef HAS_LIRC
-#endif
-
-// EGL detected. Dont use GLX!
-#ifdef HAVE_LIBEGL
-#undef HAS_GLX
-#define HAS_EGL
 #endif
 
 // GLES2.0 detected. Dont use GL!

--- a/xbmc/windowing/WindowingFactory.h
+++ b/xbmc/windowing/WindowingFactory.h
@@ -29,7 +29,10 @@
 #elif defined(TARGET_WINDOWS) && defined(HAS_DX)
 #include "windows/WinSystemWin32DX.h"
 
-#elif defined(TARGET_LINUX)   && defined(HAVE_X11)
+#elif defined(TARGET_LINUX)   && defined(HAVE_X11)   && defined(HAS_GLES)
+#include "X11/WinSystemX11GLESContext.h"
+
+#elif defined(TARGET_LINUX)   && defined(HAVE_X11)   && defined(HAS_GL)
 #include "X11/WinSystemX11GLContext.h"
 
 #elif defined(TARGET_LINUX)   && defined(HAS_GLES) && defined(HAS_EGL) && !defined(HAVE_X11)

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -21,12 +21,8 @@
 #pragma once
 
 #if defined(HAVE_X11)
-#include "GL/glx.h"
-#include "EGL/egl.h"
 #include "X11/Xlib.h"
 #include "guilib/DirtyRegion.h"
-
-#define EGL_NO_CONFIG (EGLConfig)0
 
 class CGLContext
 {
@@ -35,12 +31,6 @@ public:
   {
     m_dpy = dpy;
     m_extensions = "";
-    m_glxWindow = 0;
-    m_glxContext = 0;
-    m_eglDisplay = EGL_NO_DISPLAY;
-    m_eglSurface = EGL_NO_SURFACE;
-    m_eglContext = EGL_NO_CONTEXT;
-    m_eglConfig = EGL_NO_CONFIG;
   }
   virtual bool Refresh(bool force, int screen, Window glWindow, bool &newContext) = 0;
   virtual void Destroy() = 0;
@@ -55,12 +45,6 @@ public:
   std::string m_extensions;
 
   Display *m_dpy;
-  GLXWindow m_glxWindow;
-  GLXContext m_glxContext;
-  EGLDisplay m_eglDisplay;
-  EGLSurface m_eglSurface;
-  EGLContext m_eglContext;
-  EGLConfig m_eglConfig;
 };
 
 #endif

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -17,17 +17,35 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-
 #include "system.h"
 
-#if defined(HAVE_X11)
+#if defined(HAVE_X11) && defined(HAS_EGL)
+
+#ifdef HAS_GL
+  // always define GL_GLEXT_PROTOTYPES before include gl headers
+  #if !defined(GL_GLEXT_PROTOTYPES)
+    #define GL_GLEXT_PROTOTYPES
+  #endif
+  #include <GL/gl.h>
+  #include <GL/glu.h>
+  #include <GL/glext.h>
+#elif HAS_GLES == 2
+  #include <GLES2/gl2.h>
+  #include <GLES2/gl2ext.h>
+#endif
 
 #include "GLContextEGL.h"
 #include "utils/log.h"
 
+#define EGL_NO_CONFIG (EGLConfig)0
+
 CGLContextEGL::CGLContextEGL(Display *dpy) : CGLContext(dpy)
 {
   m_extPrefix = "EGL_";
+  m_eglDisplay = EGL_NO_DISPLAY;
+  m_eglSurface = EGL_NO_SURFACE;
+  m_eglContext = EGL_NO_CONTEXT;
+  m_eglConfig = EGL_NO_CONFIG;
 }
 
 CGLContextEGL::~CGLContextEGL()
@@ -165,7 +183,10 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
     }
 #endif
 
-    m_eglConfig = getEGLConfig(m_eglDisplay, vInfo);
+    if(m_eglConfig == EGL_NO_CONFIG)
+    {
+      m_eglConfig = getEGLConfig(m_eglDisplay, vInfo);
+    }
 
     if (m_eglConfig == EGL_NO_CONFIG)
     {
@@ -362,6 +383,53 @@ bool CGLContextEGL::IsExtSupported(const char* extension)
   name += " ";
 
   return m_extensions.find(name) != std::string::npos;
+}
+
+XVisualInfo* CGLContextEGL::GetVisual()
+{
+    GLint att[] =
+    {
+      EGL_RED_SIZE, 8,
+      EGL_GREEN_SIZE, 8,
+      EGL_BLUE_SIZE, 8,
+      EGL_ALPHA_SIZE, 8,
+      EGL_BUFFER_SIZE, 32,
+      EGL_DEPTH_SIZE, 24,
+      EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+      EGL_NONE
+    };
+
+    if (m_eglDisplay == EGL_NO_DISPLAY)
+    {
+      m_eglDisplay = eglGetDisplay((EGLNativeDisplayType)m_dpy);
+      if (m_eglDisplay == EGL_NO_DISPLAY)
+      {
+        CLog::Log(LOGERROR, "failed to get egl display\n");
+	return NULL;
+      }
+      if (!eglInitialize(m_eglDisplay, NULL, NULL))
+      {
+	CLog::Log(LOGERROR, "failed to initialize egl display\n");
+	return NULL;
+      }
+    }
+
+    EGLint numConfigs;
+    EGLConfig eglConfig = 0;
+    if (!eglChooseConfig(m_eglDisplay, att, &eglConfig, 1, &numConfigs) || numConfigs == 0) {
+      CLog::Log(LOGERROR, "Failed to choose a config %d\n", eglGetError());
+    }
+    m_eglConfig=eglConfig;
+
+    XVisualInfo x11_visual_info_template;
+    if (!eglGetConfigAttrib(m_eglDisplay, m_eglConfig, EGL_NATIVE_VISUAL_ID, (EGLint*)&x11_visual_info_template.visualid)) {
+      CLog::Log(LOGERROR, "Failed to query native visual id\n");
+    }
+    int num_visuals;
+    return XGetVisualInfo(m_dpy,
+                        VisualIDMask,
+			&x11_visual_info_template,
+			&num_visuals);
 }
 
 #endif

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -36,6 +36,11 @@ public:
   virtual bool SwapBuffers(const CDirtyRegionList& dirty, int &mode);
   virtual void QueryExtensions();
   virtual bool IsExtSupported(const char* extension);
+  XVisualInfo* GetVisual();
+  EGLDisplay m_eglDisplay;
+  EGLSurface m_eglSurface;
+  EGLContext m_eglContext;
+  EGLConfig m_eglConfig;
 protected:
   bool IsSuitableVisual(XVisualInfo *vInfo);
   EGLConfig getEGLConfig(EGLDisplay eglDisplay, XVisualInfo *vInfo);

--- a/xbmc/windowing/X11/GLContextGLX.cpp
+++ b/xbmc/windowing/X11/GLContextGLX.cpp
@@ -20,7 +20,7 @@
 
 #include "system_gl.h"
 
-#if defined(HAVE_X11)
+#if defined(HAVE_X11) && defined(HAS_GL)
 
 #include <GL/glx.h>
 #include "GLContextGLX.h"
@@ -29,6 +29,8 @@
 CGLContextGLX::CGLContextGLX(Display *dpy) : CGLContext(dpy)
 {
   m_extPrefix = "GLX_";
+  m_glxWindow = 0;
+  m_glxContext = 0;
 }
 
 bool CGLContextGLX::Refresh(bool force, int screen, Window glWindow, bool &newContext)

--- a/xbmc/windowing/X11/GLContextGLX.h
+++ b/xbmc/windowing/X11/GLContextGLX.h
@@ -35,6 +35,8 @@ public:
   virtual bool SwapBuffers(const CDirtyRegionList& dirty, int &mode);
   virtual void QueryExtensions();
   virtual bool IsExtSupported(const char* extension);
+  GLXWindow m_glxWindow;
+  GLXContext m_glxContext;
 protected:
   bool IsSuitableVisual(XVisualInfo *vInfo);
 

--- a/xbmc/windowing/X11/Makefile
+++ b/xbmc/windowing/X11/Makefile
@@ -1,5 +1,6 @@
 SRCS=WinSystemX11.cpp \
      WinSystemX11GLContext.cpp \
+     WinSystemX11GLESContext.cpp \
      GLContextEGL.cpp \
      GLContextGLX.cpp \
      XRandR.cpp \

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -19,12 +19,14 @@
  */
 #include "system.h"
 
-#if defined(HAVE_X11)
+#if defined(HAVE_X11) && defined(HAS_GL)
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
 #include "WinSystemX11GLContext.h"
+#include "GLContextGLX.h"
+#include "GLContextEGL.h"
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "guilib/GraphicContext.h"
@@ -32,8 +34,6 @@
 #include "threads/SingleLock.h"
 #include <vector>
 #include "Application.h"
-#include "GLContextEGL.h"
-#include "GLContextGLX.h"
 
 CWinSystemX11GLContext::CWinSystemX11GLContext()
 {
@@ -69,6 +69,36 @@ bool CWinSystemX11GLContext::IsExtSupported(const char* extension)
     return CRenderSystemGL::IsExtSupported(extension);
 
   return m_pGLContext->IsExtSupported(extension);
+}
+
+GLXWindow CWinSystemX11GLContext::GetWindow() const
+{
+  return static_cast<CGLContextGLX*>(m_pGLContext)->m_glxWindow;
+}
+
+GLXContext CWinSystemX11GLContext::GetGlxContext() const
+{
+  return static_cast<CGLContextGLX*>(m_pGLContext)->m_glxContext;
+}
+
+EGLDisplay CWinSystemX11GLContext::GetEGLDisplay() const
+{
+  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglDisplay;
+}
+
+EGLSurface CWinSystemX11GLContext::GetEGLSurface() const
+{
+  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglSurface;
+}
+
+EGLContext CWinSystemX11GLContext::GetEGLContext() const
+{
+  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglContext;
+}
+
+EGLConfig CWinSystemX11GLContext::GetEGLConfig() const
+{
+  return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglConfig;
 }
 
 bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate)

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -1,0 +1,171 @@
+#include "system.h"
+
+#if defined(HAVE_X11) && defined(HAS_EGL)
+
+#include "WinSystemX11GLESContext.h"
+#include "utils/log.h"
+#include "guilib/GraphicContext.h"
+#include "guilib/DispResource.h"
+#include "threads/SingleLock.h"
+#include "Application.h"
+
+CWinSystemX11GLESContext::CWinSystemX11GLESContext()
+{
+  m_pGLContext = NULL;
+}
+
+CWinSystemX11GLESContext::~CWinSystemX11GLESContext()
+{
+  delete m_pGLContext;
+}
+
+bool CWinSystemX11GLESContext::PresentRenderImpl(const CDirtyRegionList& dirty)
+{
+  m_pGLContext->SwapBuffers(dirty, m_iVSyncMode);
+  if (m_delayDispReset && m_dispResetTimer.IsTimePast())
+  {
+    m_delayDispReset = false;
+    CSingleLock lock(m_resourceSection);
+    // tell any shared resources
+    for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
+      (*i)->OnResetDisplay();
+  }
+}
+
+void CWinSystemX11GLESContext::SetVSyncImpl(bool enable)
+{
+  m_pGLContext->SetVSync(enable, m_iVSyncMode);
+}
+
+bool CWinSystemX11GLESContext::IsExtSupported(const char* extension)
+{
+  if(strncmp(extension, m_pGLContext->ExtPrefix().c_str(), 4) != 0)
+    return CRenderSystemGLES::IsExtSupported(extension);
+
+  return m_pGLContext->IsExtSupported(extension);
+}
+
+bool CWinSystemX11GLESContext::SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate)
+{
+  int newwin = 0;
+  CWinSystemX11::SetWindow(width, height, fullscreen, output, &newwin);
+  if (newwin)
+  {
+    CDirtyRegionList dr;
+    RefreshGLContext(m_currentOutput.compare(output) != 0);
+    XSync(m_dpy, FALSE);
+    g_graphicsContext.Clear(0);
+    g_graphicsContext.Flip(dr);
+    ResetVSync();
+
+    m_windowDirty = false;
+    m_bIsInternalXrr = false;
+
+    if (!m_delayDispReset)
+    {
+      CSingleLock lock(m_resourceSection);
+      // tell any shared resources
+      for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
+        (*i)->OnResetDisplay();
+    }
+  }
+  return true;
+}
+
+bool CWinSystemX11GLESContext::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
+{
+  CLog::Log(LOGNOTICE, "CWinSystemX11GLESContext::CreateNewWindow");
+  if(!CWinSystemX11::CreateNewWindow(name, fullScreen, res, userFunction))
+    return false;
+
+  m_pGLContext->QueryExtensions();
+  return true;
+}
+
+bool CWinSystemX11GLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
+{
+  m_newGlContext = false;
+  CWinSystemX11::ResizeWindow(newWidth, newHeight, newLeft, newTop);
+  CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight, false, 0);
+
+  if (m_newGlContext)
+    g_application.ReloadSkin();
+
+  return true;
+}
+
+bool CWinSystemX11GLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
+{
+  m_newGlContext = false;
+  CWinSystemX11::SetFullScreen(fullScreen, res, blankOtherDisplays);
+  CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+
+  if (m_newGlContext)
+    g_application.ReloadSkin();
+
+  return true;
+}
+
+bool CWinSystemX11GLESContext::DestroyWindowSystem()
+{
+  bool ret;
+  m_pGLContext->Destroy();
+  ret = CWinSystemX11::DestroyWindowSystem();
+  return ret;
+}
+
+bool CWinSystemX11GLESContext::DestroyWindow()
+{
+  bool ret;
+  m_pGLContext->Detach();
+  ret = CWinSystemX11::DestroyWindow();
+  return ret;
+}
+
+XVisualInfo* CWinSystemX11GLESContext::GetVisual()
+{
+  CLog::Log(LOGNOTICE, "CWinSystemX11GLESContext::GetVisual() m_pGLContext:%p GetVisual", m_pGLContext);
+  if(!m_pGLContext)
+  {
+    CLog::Log(LOGNOTICE, "Create new CGLContextEGL at CWinSystemX11GLESContext::CreateNewWindow, m_dpy=%p", m_dpy);
+    m_pGLContext = new CGLContextEGL(m_dpy);
+  }
+  return m_pGLContext->GetVisual();
+}
+
+bool CWinSystemX11GLESContext::RefreshGLContext(bool force)
+{
+  bool firstrun = false;
+  if (!m_pGLContext)
+  {
+    m_pGLContext = new CGLContextEGL(m_dpy);
+    firstrun = true;
+  }
+  bool ret = m_pGLContext->Refresh(force, m_nScreen, m_glWindow, m_newGlContext);
+
+  if (ret && !firstrun)
+    return ret;
+
+  std::string gpuvendor;
+  if (ret)
+  {
+    const char* vend = (const char*) glGetString(GL_VENDOR);
+    if (vend)
+      gpuvendor = vend;
+  }
+  std::transform(gpuvendor.begin(), gpuvendor.end(), gpuvendor.begin(), ::tolower);
+  if (firstrun && (!ret || gpuvendor.compare(0, 5, "intel") != 0))
+  {
+    delete m_pGLContext;
+    m_pGLContext = new CGLContextEGL(m_dpy);
+    ret = m_pGLContext->Refresh(force, m_nScreen, m_glWindow, m_newGlContext);
+  }
+  return ret;
+}
+
+bool CWinSystemX11GLESContext::DestroyGLContext()
+{
+  m_pGLContext->Destroy();
+}
+
+#endif

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -21,20 +21,18 @@
 #pragma once
 
 #if defined(HAVE_X11)
-
 #include "WinSystemX11.h"
-#include "GL/glx.h"
-#include "EGL/egl.h"
-#include "rendering/gl/RenderSystemGL.h"
 #include "utils/GlobalsHandling.h"
+#include "rendering/gles/RenderSystemGLES.h"
+#include "GLContextEGL.h"
+#include "EGL/egl.h"
 
-class CGLContext;
-
-class CWinSystemX11GLContext : public CWinSystemX11, public CRenderSystemGL
+class CWinSystemX11GLESContext : public CWinSystemX11, public CRenderSystemGLES
 {
 public:
-  CWinSystemX11GLContext();
-  virtual ~CWinSystemX11GLContext();
+  CWinSystemX11GLESContext();
+  virtual ~CWinSystemX11GLESContext();
+
   virtual bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction);
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
@@ -43,12 +41,10 @@ public:
 
   virtual bool IsExtSupported(const char* extension);
 
-  GLXWindow GetWindow() const;
-  GLXContext GetGlxContext() const;
-  EGLDisplay GetEGLDisplay() const;
-  EGLSurface GetEGLSurface() const;
-  EGLContext GetEGLContext() const;
-  EGLConfig GetEGLConfig() const;
+  EGLDisplay GetEGLDisplay() const { return  m_pGLContext->m_eglDisplay; }
+  EGLSurface GetEGLSurface() const { return  m_pGLContext->m_eglSurface; }
+  EGLContext GetEGLContext() const { return  m_pGLContext->m_eglContext; }
+  EGLConfig GetEGLConfig() const { return  m_pGLContext->m_eglConfig; }
 
 protected:
   virtual bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL);
@@ -58,11 +54,10 @@ protected:
   virtual bool DestroyGLContext();
   virtual XVisualInfo* GetVisual();
 
-  CGLContext *m_pGLContext;
+  CGLContextEGL *m_pGLContext;
   bool m_newGlContext;
 };
 
-XBMC_GLOBAL_REF(CWinSystemX11GLContext,g_Windowing);
-#define g_Windowing XBMC_GLOBAL_USE(CWinSystemX11GLContext)
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemX11GLESContext)
 
-#endif //HAVE_X11
+#endif


### PR DESCRIPTION
With this patch the code is able to compile and run properly on an EGL/GLES2 target over X11.
The changes from https://github.com/xbmc/xbmc/pull/8234 have been merged, too.
I tried to keep modifications to the absolute necessary ones to make it work, therefore the refactoring is still in progress.
Currently the classes *CWinSystemX11GLContextEGL* and *CWinSystemX11GLContext* have exactly the same interface, therefore in a future version can be easily derived from a common class.