### PR TITLE
ffmpeg: Update AVPixelFormat and AV_PIX_FMT_* to compile with master

### DIFF
--- a/xbmc/cores/FFmpeg.h
+++ b/xbmc/cores/FFmpeg.h
@@ -24,30 +24,12 @@
 #include "utils/CPUInfo.h"
 
 extern "C" {
-#include "libswscale/swscale.h"
 #include "libavcodec/avcodec.h"
 #include "libavformat/avformat.h"
 #include "libavutil/avutil.h"
 #include "libavutil/ffversion.h"
 #include "libavfilter/avfilter.h"
 #include "libpostproc/postprocess.h"
-}
-
-inline int SwScaleCPUFlags()
-{
-  unsigned int cpuFeatures = g_cpuInfo.GetCPUFeatures();
-  int flags = 0;
-
-  if (cpuFeatures & CPU_FEATURE_MMX)
-    flags |= SWS_CPU_CAPS_MMX;
-  if (cpuFeatures & CPU_FEATURE_MMX2)
-    flags |= SWS_CPU_CAPS_MMX2;
-  if (cpuFeatures & CPU_FEATURE_3DNOW)
-    flags |= SWS_CPU_CAPS_3DNOW;
-  if (cpuFeatures & CPU_FEATURE_ALTIVEC)
-    flags |= SWS_CPU_CAPS_ALTIVEC;
-
-  return flags;
 }
 
 inline int PPCPUFlags()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodecUtils.cpp
@@ -39,7 +39,7 @@ extern "C" {
 #include "libswscale/swscale.h"
 }
 
-// allocate a new picture (PIX_FMT_YUV420P)
+// allocate a new picture (AV_PIX_FMT_YUV420P)
 DVDVideoPicture* CDVDCodecUtils::AllocatePicture(int iWidth, int iHeight)
 {
   DVDVideoPicture* pPicture = new DVDVideoPicture;
@@ -264,13 +264,13 @@ DVDVideoPicture* CDVDCodecUtils::ConvertToYUV422PackedPicture(DVDVideoPicture *p
 
         int dstformat;
         if (format == RENDER_FMT_UYVY422)
-          dstformat = PIX_FMT_UYVY422;
+          dstformat = AV_PIX_FMT_UYVY422;
         else
-          dstformat = PIX_FMT_YUYV422;
+          dstformat = AV_PIX_FMT_YUYV422;
 
-        struct SwsContext *ctx = sws_getContext(pSrc->iWidth, pSrc->iHeight, PIX_FMT_YUV420P,
+        struct SwsContext *ctx = sws_getContext(pSrc->iWidth, pSrc->iHeight, AV_PIX_FMT_YUV420P,
                                                            pPicture->iWidth, pPicture->iHeight, (AVPixelFormat)dstformat,
-                                                           SWS_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                                                           SWS_BILINEAR, NULL, NULL, NULL);
         sws_scale(ctx, src, srcStride, 0, pSrc->iHeight, dst, dstStride);
         sws_freeContext(ctx);
       }
@@ -403,25 +403,25 @@ double CDVDCodecUtils::NormalizeFrameduration(double frameduration, bool *match)
 }
 
 struct EFormatMap {
-  PixelFormat   pix_fmt;
+  AVPixelFormat   pix_fmt;
   ERenderFormat format;
 };
 
 static const EFormatMap g_format_map[] = {
-   { PIX_FMT_YUV420P,     RENDER_FMT_YUV420P    }
-,  { PIX_FMT_YUVJ420P,    RENDER_FMT_YUV420P    }
-,  { PIX_FMT_YUV420P10,   RENDER_FMT_YUV420P10  }
-,  { PIX_FMT_YUV420P16,   RENDER_FMT_YUV420P16  }
-,  { PIX_FMT_UYVY422,     RENDER_FMT_UYVY422    }
-,  { PIX_FMT_YUYV422,     RENDER_FMT_YUYV422    }
-,  { PIX_FMT_VAAPI_VLD,   RENDER_FMT_VAAPI      }
-,  { PIX_FMT_DXVA2_VLD,   RENDER_FMT_DXVA       }
-,  { PIX_FMT_NONE     ,   RENDER_FMT_NONE       }
+   { AV_PIX_FMT_YUV420P,     RENDER_FMT_YUV420P    }
+,  { AV_PIX_FMT_YUVJ420P,    RENDER_FMT_YUV420P    }
+,  { AV_PIX_FMT_YUV420P10,   RENDER_FMT_YUV420P10  }
+,  { AV_PIX_FMT_YUV420P16,   RENDER_FMT_YUV420P16  }
+,  { AV_PIX_FMT_UYVY422,     RENDER_FMT_UYVY422    }
+,  { AV_PIX_FMT_YUYV422,     RENDER_FMT_YUYV422    }
+,  { AV_PIX_FMT_VAAPI_VLD,   RENDER_FMT_VAAPI      }
+,  { AV_PIX_FMT_DXVA2_VLD,   RENDER_FMT_DXVA       }
+,  { AV_PIX_FMT_NONE     ,   RENDER_FMT_NONE       }
 };
 
 ERenderFormat CDVDCodecUtils::EFormatFromPixfmt(int fmt)
 {
-  for(const EFormatMap *p = g_format_map; p->pix_fmt != PIX_FMT_NONE; ++p)
+  for(const EFormatMap *p = g_format_map; p->pix_fmt != AV_PIX_FMT_NONE; ++p)
   {
     if(p->pix_fmt == fmt)
       return p->format;
@@ -431,10 +431,10 @@ ERenderFormat CDVDCodecUtils::EFormatFromPixfmt(int fmt)
 
 int CDVDCodecUtils::PixfmtFromEFormat(ERenderFormat fmt)
 {
-  for(const EFormatMap *p = g_format_map; p->pix_fmt != PIX_FMT_NONE; ++p)
+  for(const EFormatMap *p = g_format_map; p->pix_fmt != AV_PIX_FMT_NONE; ++p)
   {
     if(p->format == fmt)
       return p->pix_fmt;
   }
-  return PIX_FMT_NONE;
+  return AV_PIX_FMT_NONE;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -77,8 +77,8 @@ enum DecoderState
   STATE_SW_MULTI
 };
 
-enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
-                                                , const PixelFormat * fmt )
+enum AVPixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
+                                                , const AVPixelFormat * fmt )
 {
   CDVDVideoCodecFFmpeg* ctx  = (CDVDVideoCodecFFmpeg*)avctx->opaque;
 
@@ -104,8 +104,8 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
     avctx->hwaccel_context = 0;
   }
 
-  const PixelFormat * cur = fmt;
-  while(*cur != PIX_FMT_NONE)
+  const AVPixelFormat * cur = fmt;
+  while(*cur != AV_PIX_FMT_NONE)
   {
 #ifdef HAVE_LIBVDPAU
     if(VDPAU::CDecoder::IsVDPAUFormat(*cur) && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVDPAU))
@@ -137,7 +137,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
 #endif
 #ifdef HAVE_LIBVA
     // mpeg4 vaapi decoding is disabled
-    if(*cur == PIX_FMT_VAAPI_VLD && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVAAPI))
+    if(*cur == AV_PIX_FMT_VAAPI_VLD && CSettings::GetInstance().GetBool(CSettings::SETTING_VIDEOPLAYER_USEVAAPI))
     {
       VAAPI::CDecoder* dec = new VAAPI::CDecoder();
       if(dec->Open(avctx, ctx->m_pCodecContext, *cur, ctx->m_uSurfacesCount) == true)
@@ -214,11 +214,11 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   for(std::vector<ERenderFormat>::iterator it = options.m_formats.begin(); it != options.m_formats.end(); ++it)
   {
-    m_formats.push_back((PixelFormat)CDVDCodecUtils::PixfmtFromEFormat(*it));
+    m_formats.push_back((AVPixelFormat)CDVDCodecUtils::PixfmtFromEFormat(*it));
     if(*it == RENDER_FMT_YUV420P)
-      m_formats.push_back(PIX_FMT_YUVJ420P);
+      m_formats.push_back(AV_PIX_FMT_YUVJ420P);
   }
-  m_formats.push_back(PIX_FMT_NONE); /* always add none to get a terminated list in ffmpeg world */
+  m_formats.push_back(AV_PIX_FMT_NONE); /* always add none to get a terminated list in ffmpeg world */
 
   pCodec = avcodec_find_decoder(hints.codec);
 
@@ -658,7 +658,7 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(DVDVideoPicture* pDvdVideoPicture)
   pDvdVideoPicture->color_transfer = m_pCodecContext->color_trc;
   pDvdVideoPicture->color_matrix = m_pCodecContext->colorspace;
   if(m_pCodecContext->color_range == AVCOL_RANGE_JPEG
-  || m_pCodecContext->pix_fmt     == PIX_FMT_YUVJ420P)
+  || m_pCodecContext->pix_fmt     == AV_PIX_FMT_YUVJ420P)
     pDvdVideoPicture->color_range = 1;
   else
     pDvdVideoPicture->color_range = 0;
@@ -741,8 +741,8 @@ bool CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
   pDvdVideoPicture->iFlags |= pDvdVideoPicture->data[0] ? 0 : DVP_FLAG_DROPPED;
   pDvdVideoPicture->extended_format = 0;
 
-  PixelFormat pix_fmt;
-  pix_fmt = (PixelFormat)m_pFrame->format;
+  AVPixelFormat pix_fmt;
+  pix_fmt = (AVPixelFormat)m_pFrame->format;
 
   pDvdVideoPicture->format = CDVDCodecUtils::EFormatFromPixfmt(pix_fmt);
   return true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -46,7 +46,7 @@ public:
     public:
              IHardwareDecoder() {}
     virtual ~IHardwareDecoder() {};
-    virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat, unsigned int surfaces) = 0;
+    virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces) = 0;
     virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame) = 0;
     virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture) = 0;
     virtual int  Check     (AVCodecContext* avctx) = 0;
@@ -77,7 +77,7 @@ public:
   void               SetHardware(IHardwareDecoder* hardware);
 
 protected:
-  static enum PixelFormat GetFormat(struct AVCodecContext * avctx, const PixelFormat * fmt);
+  static enum AVPixelFormat GetFormat(struct AVCodecContext * avctx, const AVPixelFormat * fmt);
 
   int  FilterOpen(const std::string& filters, bool scale);
   void FilterClose();
@@ -119,7 +119,7 @@ protected:
   int m_iLastKeyframe;
   double m_dts;
   bool   m_started;
-  std::vector<PixelFormat> m_formats;
+  std::vector<AVPixelFormat> m_formats;
   double m_decoderPts;
   int    m_skippedDeint;
   bool   m_requestSkipDeint;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecVDA.cpp
@@ -554,11 +554,11 @@ void CDVDVideoCodecVDA::DisplayQueuePop(void)
 
 void CDVDVideoCodecVDA::UYVY422_to_YUV420P(uint8_t *yuv422_ptr, int yuv422_stride, DVDVideoPicture *picture)
 {
-  // convert PIX_FMT_UYVY422 to PIX_FMT_YUV420P.
+  // convert AV_PIX_FMT_UYVY422 to AV_PIX_FMT_YUV420P.
   struct SwsContext *swcontext = sws_getContext(
-    m_videobuffer.iWidth, m_videobuffer.iHeight, PIX_FMT_UYVY422, 
-    m_videobuffer.iWidth, m_videobuffer.iHeight, PIX_FMT_YUV420P, 
-    SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+    m_videobuffer.iWidth, m_videobuffer.iHeight, AV_PIX_FMT_UYVY422,
+    m_videobuffer.iWidth, m_videobuffer.iHeight, AV_PIX_FMT_YUV420P,
+    SWS_FAST_BILINEAR, NULL, NULL, NULL);
   if (swcontext)
   {
     uint8_t  *src[] = { yuv422_ptr, 0, 0, 0 };
@@ -574,11 +574,11 @@ void CDVDVideoCodecVDA::UYVY422_to_YUV420P(uint8_t *yuv422_ptr, int yuv422_strid
 
 void CDVDVideoCodecVDA::BGRA_to_YUV420P(uint8_t *bgra_ptr, int bgra_stride, DVDVideoPicture *picture)
 {
-  // convert PIX_FMT_BGRA to PIX_FMT_YUV420P.
+  // convert AV_PIX_FMT_BGRA to AV_PIX_FMT_YUV420P.
   struct SwsContext *swcontext = sws_getContext(
-    m_videobuffer.iWidth, m_videobuffer.iHeight, PIX_FMT_BGRA, 
-    m_videobuffer.iWidth, m_videobuffer.iHeight, PIX_FMT_YUV420P, 
-    SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+    m_videobuffer.iWidth, m_videobuffer.iHeight, AV_PIX_FMT_BGRA,
+    m_videobuffer.iWidth, m_videobuffer.iHeight, AV_PIX_FMT_YUV420P,
+    SWS_FAST_BILINEAR, NULL, NULL, NULL);
   if (swcontext)
   {
     uint8_t  *src[] = { bgra_ptr, 0, 0, 0 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -886,7 +886,7 @@ static bool CheckCompatibility(AVCodecContext *avctx)
   return true;
 }
 
-bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum PixelFormat fmt, unsigned int surfaces)
+bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixelFormat fmt, unsigned int surfaces)
 {
   if (!CheckCompatibility(avctx))
     return false;
@@ -1135,9 +1135,9 @@ bool CDecoder::OpenDecoder()
   return true;
 }
 
-bool CDecoder::Supports(enum PixelFormat fmt)
+bool CDecoder::Supports(enum AVPixelFormat fmt)
 {
-  if(fmt == PIX_FMT_DXVA2_VLD)
+  if(fmt == AV_PIX_FMT_DXVA2_VLD)
     return true;
   return false;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -141,7 +141,7 @@ class CDecoder
 public:
   CDecoder();
  ~CDecoder();
-  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat, unsigned int surfaces);
+  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual int  Check     (AVCodecContext* avctx);
@@ -154,7 +154,7 @@ public:
   int   GetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
   void  RelBuffer(uint8_t *data);
 
-  static bool      Supports(enum PixelFormat fmt);
+  static bool      Supports(enum AVPixelFormat fmt);
 
   void CloseDXVADecoder();
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -476,7 +476,7 @@ CDecoder::~CDecoder()
   Close();
 }
 
-bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat fmt, unsigned int surfaces)
+bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat fmt, unsigned int surfaces)
 {
   // don't support broken wrappers by default
   // nvidia cards with a vaapi to vdpau wrapper

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -413,7 +413,7 @@ public:
   CDecoder();
   virtual ~CDecoder();
 
-  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat, unsigned int surfaces = 0);
+  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces = 0);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual void Reset();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDA.cpp
@@ -186,7 +186,7 @@ void CDecoder::Close()
   m_bitstream = NULL;
 }
 
-bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum PixelFormat fmt, unsigned int surfaces)
+bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixelFormat fmt, unsigned int surfaces)
 {
   Close();
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDA.h
@@ -35,7 +35,7 @@ class CDecoder
 public:
   CDecoder();
  ~CDecoder();
-  virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat, unsigned int surfaces = 0);
+  virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces = 0);
   virtual int Decode(AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual int Check(AVCodecContext* avctx);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -486,7 +486,7 @@ CDecoder::CDecoder() : m_vdpauOutput(&m_inMsgEvent)
   m_vdpauConfig.context = 0;
 }
 
-bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat fmt, unsigned int surfaces)
+bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat fmt, unsigned int surfaces)
 {
   // check if user wants to decode this format with VDPAU
   std::string gpuvendor = g_Windowing.GetRenderVendor();
@@ -760,7 +760,7 @@ int CDecoder::Check(AVCodecContext* avctx)
   return 0;
 }
 
-bool CDecoder::IsVDPAUFormat(PixelFormat format)
+bool CDecoder::IsVDPAUFormat(AVPixelFormat format)
 {
   if (format == AV_PIX_FMT_VDPAU)
     return true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -557,7 +557,7 @@ public:
   CDecoder();
   virtual ~CDecoder();
 
-  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum PixelFormat, unsigned int surfaces = 0);
+  virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces = 0);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual void Reset();
@@ -572,7 +572,7 @@ public:
   bool Supports(VdpVideoMixerFeature feature);
   bool Supports(EINTERLACEMETHOD method);
   EINTERLACEMETHOD AutoInterlaceMethod();
-  static bool IsVDPAUFormat(PixelFormat fmt);
+  static bool IsVDPAUFormat(AVPixelFormat fmt);
 
   static void FFReleaseBuffer(void *opaque, uint8_t *data);
   static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1643,7 +1643,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket *pkt)
 
   // for video we need a decoder to get desired information into codec context
   if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO && st->codec->extradata &&
-      (!st->codec->width || st->codec->pix_fmt == PIX_FMT_NONE))
+      (!st->codec->width || st->codec->pix_fmt == AV_PIX_FMT_NONE))
   {
     // open a decoder, it will be cleared down by ffmpeg on closing the stream
     if (!st->codec->codec)
@@ -1700,7 +1700,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
       st = m_pFormatContext->streams[idx];
       if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (st->codec->width && st->codec->pix_fmt != PIX_FMT_NONE)
+        if (st->codec->width && st->codec->pix_fmt != AV_PIX_FMT_NONE)
           return true;
         hasVideo = true;
       }
@@ -1713,7 +1713,7 @@ bool CDVDDemuxFFmpeg::IsVideoReady()
       st = m_pFormatContext->streams[i];
       if (st->codec->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (st->codec->width && st->codec->pix_fmt != PIX_FMT_NONE)
+        if (st->codec->width && st->codec->pix_fmt != AV_PIX_FMT_NONE)
           return true;
         hasVideo = true;
       }

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -277,7 +277,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
 
             uint8_t *pOutBuf = new uint8_t[nWidth * nHeight * 4];
             struct SwsContext *context = sws_getContext(picture.iWidth, picture.iHeight,
-                  PIX_FMT_YUV420P, nWidth, nHeight, PIX_FMT_BGRA, SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                  AV_PIX_FMT_YUV420P, nWidth, nHeight, AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
 
             if (context)
             {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -2451,7 +2451,7 @@ void CLinuxRendererGL::ToRGBFrame(YV12Image* im, unsigned flipIndexPlane, unsign
   }
   else if (m_format == RENDER_FMT_NV12)
   {
-    srcFormat = PIX_FMT_NV12;
+    srcFormat = AV_PIX_FMT_NV12;
     for (int i = 0; i < 2; i++)
     {
       src[i]       = im->plane[i];
@@ -2460,13 +2460,13 @@ void CLinuxRendererGL::ToRGBFrame(YV12Image* im, unsigned flipIndexPlane, unsign
   }
   else if (m_format == RENDER_FMT_YUYV422)
   {
-    srcFormat    = PIX_FMT_YUYV422;
+    srcFormat    = AV_PIX_FMT_YUYV422;
     src[0]       = im->plane[0];
     srcStride[0] = im->stride[0];
   }
   else if (m_format == RENDER_FMT_UYVY422)
   {
-    srcFormat    = PIX_FMT_UYVY422;
+    srcFormat    = AV_PIX_FMT_UYVY422;
     src[0]       = im->plane[0];
     srcStride[0] = im->stride[0];
   }
@@ -2484,8 +2484,8 @@ void CLinuxRendererGL::ToRGBFrame(YV12Image* im, unsigned flipIndexPlane, unsign
 
   m_context = sws_getCachedContext(m_context,
                                                  im->width, im->height, (AVPixelFormat)srcFormat,
-                                                 im->width, im->height, (AVPixelFormat)PIX_FMT_BGRA,
-                                                 SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                                                 im->width, im->height, (AVPixelFormat)AV_PIX_FMT_BGRA,
+                                                 SWS_FAST_BILINEAR, NULL, NULL, NULL);
 
   uint8_t *dst[]       = { m_rgbBuffer, 0, 0, 0 };
   int      dstStride[] = { (int)m_sourceWidth * 4, 0, 0, 0 };
@@ -2514,7 +2514,7 @@ void CLinuxRendererGL::ToRGBFields(YV12Image* im, unsigned flipIndexPlaneTop, un
 
   if (m_format == RENDER_FMT_YUV420P)
   {
-    srcFormat = PIX_FMT_YUV420P;
+    srcFormat = AV_PIX_FMT_YUV420P;
     for (int i = 0; i < 3; i++)
     {
       srcTop[i]       = im->plane[i];
@@ -2525,7 +2525,7 @@ void CLinuxRendererGL::ToRGBFields(YV12Image* im, unsigned flipIndexPlaneTop, un
   }
   else if (m_format == RENDER_FMT_NV12)
   {
-    srcFormat = PIX_FMT_NV12;
+    srcFormat = AV_PIX_FMT_NV12;
     for (int i = 0; i < 2; i++)
     {
       srcTop[i]       = im->plane[i];
@@ -2536,7 +2536,7 @@ void CLinuxRendererGL::ToRGBFields(YV12Image* im, unsigned flipIndexPlaneTop, un
   }
   else if (m_format == RENDER_FMT_YUYV422)
   {
-    srcFormat       = PIX_FMT_YUYV422;
+    srcFormat       = AV_PIX_FMT_YUYV422;
     srcTop[0]       = im->plane[0];
     srcStrideTop[0] = im->stride[0] * 2;
     srcBot[0]       = im->plane[0] + im->stride[0];
@@ -2544,7 +2544,7 @@ void CLinuxRendererGL::ToRGBFields(YV12Image* im, unsigned flipIndexPlaneTop, un
   }
   else if (m_format == RENDER_FMT_UYVY422)
   {
-    srcFormat       = PIX_FMT_UYVY422;
+    srcFormat       = AV_PIX_FMT_UYVY422;
     srcTop[0]       = im->plane[0];
     srcStrideTop[0] = im->stride[0] * 2;
     srcBot[0]       = im->plane[0] + im->stride[0];
@@ -2564,8 +2564,8 @@ void CLinuxRendererGL::ToRGBFields(YV12Image* im, unsigned flipIndexPlaneTop, un
 
   m_context = sws_getCachedContext(m_context,
                                                  im->width, im->height >> 1, (AVPixelFormat)srcFormat,
-                                                 im->width, im->height >> 1, (AVPixelFormat)PIX_FMT_BGRA,
-                                                 SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                                                 im->width, im->height >> 1, (AVPixelFormat)AV_PIX_FMT_BGRA,
+                                                 SWS_FAST_BILINEAR, NULL, NULL, NULL);
   uint8_t *dstTop[]    = { m_rgbBuffer, 0, 0, 0 };
   uint8_t *dstBot[]    = { m_rgbBuffer + m_sourceWidth * m_sourceHeight * 2, 0, 0, 0 };
   int      dstStride[] = { (int)m_sourceWidth * 4, 0, 0, 0 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1288,8 +1288,8 @@ void CLinuxRendererGLES::UploadYV12Texture(int source)
 #endif
     {
       m_sw_context = sws_getCachedContext(m_sw_context,
-        im->width, im->height, PIX_FMT_YUV420P,
-        im->width, im->height, PIX_FMT_RGBA,
+        im->width, im->height, AV_PIX_FMT_YUV420P,
+        im->width, im->height, AV_PIX_FMT_RGBA,
         SWS_FAST_BILINEAR, NULL, NULL, NULL);
 
       uint8_t *src[]  = { im->plane[0], im->plane[1], im->plane[2], 0 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -94,16 +94,16 @@ CWinRenderer::~CWinRenderer()
   UnInit();
 }
 
-static enum PixelFormat PixelFormatFromFormat(ERenderFormat format)
+static enum AVPixelFormat PixelFormatFromFormat(ERenderFormat format)
 {
-  if (format == RENDER_FMT_DXVA)      return PIX_FMT_NV12;
-  if (format == RENDER_FMT_YUV420P)   return PIX_FMT_YUV420P;
-  if (format == RENDER_FMT_YUV420P10) return PIX_FMT_YUV420P10;
-  if (format == RENDER_FMT_YUV420P16) return PIX_FMT_YUV420P16;
-  if (format == RENDER_FMT_NV12)      return PIX_FMT_NV12;
-  if (format == RENDER_FMT_UYVY422)   return PIX_FMT_UYVY422;
-  if (format == RENDER_FMT_YUYV422)   return PIX_FMT_YUYV422;
-  return PIX_FMT_NONE;
+  if (format == RENDER_FMT_DXVA)      return AV_PIX_FMT_NV12;
+  if (format == RENDER_FMT_YUV420P)   return AV_PIX_FMT_YUV420P;
+  if (format == RENDER_FMT_YUV420P10) return AV_PIX_FMT_YUV420P10;
+  if (format == RENDER_FMT_YUV420P16) return AV_PIX_FMT_YUV420P16;
+  if (format == RENDER_FMT_NV12)      return AV_PIX_FMT_NV12;
+  if (format == RENDER_FMT_UYVY422)   return AV_PIX_FMT_UYVY422;
+  if (format == RENDER_FMT_YUYV422)   return AV_PIX_FMT_YUYV422;
+  return AV_PIX_FMT_NONE;
 }
 
 void CWinRenderer::ManageTextures()
@@ -724,13 +724,13 @@ void CWinRenderer::Render(DWORD flags)
 
 void CWinRenderer::RenderSW()
 {
-  enum PixelFormat format = PixelFormatFromFormat(m_format);
+  enum AVPixelFormat format = PixelFormatFromFormat(m_format);
 
   // 1. convert yuv to rgb
   m_sw_scale_ctx = sws_getCachedContext(m_sw_scale_ctx,
                                         m_sourceWidth, m_sourceHeight, format,
-                                        m_sourceWidth, m_sourceHeight, PIX_FMT_BGRA,
-                                        SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+                                        m_sourceWidth, m_sourceHeight, AV_PIX_FMT_BGRA,
+                                        SWS_FAST_BILINEAR, NULL, NULL, NULL);
 
   YUVBuffer* buf = (YUVBuffer*)m_VideoBuffers[m_iYV12RenderBuffer];
 

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -342,9 +342,9 @@ bool CPicture::ScaleImage(uint8_t *in_pixels, unsigned int in_width, unsigned in
                           uint8_t *out_pixels, unsigned int out_width, unsigned int out_height, unsigned int out_pitch,
                           CPictureScalingAlgorithm::Algorithm scalingAlgorithm /* = CPictureScalingAlgorithm::NoAlgorithm */)
 {
-  struct SwsContext *context = sws_getContext(in_width, in_height, PIX_FMT_BGRA,
-                                                         out_width, out_height, PIX_FMT_BGRA,
-                                                         CPictureScalingAlgorithm::ToSwscale(scalingAlgorithm) | SwScaleCPUFlags(), NULL, NULL, NULL);
+  struct SwsContext *context = sws_getContext(in_width, in_height, AV_PIX_FMT_BGRA,
+                                                         out_width, out_height, AV_PIX_FMT_BGRA,
+                                                         CPictureScalingAlgorithm::ToSwscale(scalingAlgorithm), NULL, NULL, NULL);
 
   uint8_t *src[] = { in_pixels, 0, 0, 0 };
   int     srcStride[] = { (int)in_pitch, 0, 0, 0 };

--- a/xbmc/video/FFmpegVideoDecoder.cpp
+++ b/xbmc/video/FFmpegVideoDecoder.cpp
@@ -252,7 +252,7 @@ bool FFmpegVideoDecoder::nextFrame( CBaseTexture * texture )
       return false;
 
     // Due to a bug in swsscale we need to allocate one extra line of data
-    if ( avpicture_alloc( m_pFrameRGB, PIX_FMT_RGB32, m_frameRGBwidth, m_frameRGBheight + 1 ) < 0 )
+    if ( avpicture_alloc( m_pFrameRGB, AV_PIX_FMT_RGB32, m_frameRGBwidth, m_frameRGBheight + 1 ) < 0 )
       return false;
   }
 
@@ -287,7 +287,7 @@ bool FFmpegVideoDecoder::nextFrame( CBaseTexture * texture )
 
   // We got the video frame, render it into the picture buffer
   struct SwsContext * context = sws_getContext( m_pCodecCtx->width, m_pCodecCtx->height, m_pCodecCtx->pix_fmt,
-                           m_frameRGBwidth, m_frameRGBheight, PIX_FMT_RGB32, SWS_FAST_BILINEAR, NULL, NULL, NULL );
+                           m_frameRGBwidth, m_frameRGBheight, AV_PIX_FMT_RGB32, SWS_FAST_BILINEAR, NULL, NULL, NULL );
 
   sws_scale( context, m_pFrame->data, m_pFrame->linesize, 0, m_pCodecCtx->height,
                                                                      m_pFrameRGB->data, m_pFrameRGB->linesize );


### PR DESCRIPTION
The deprecated PixelFormat and PIX_FMT_* names have been removed in
ffmpeg master.

NB: None of the non-Linux changes have been tested.