### PR TITLE
AESink: Remove m_frameSamples from sink implementations

### DIFF
--- a/xbmc/addons/include/kodi_audioengine_types.h
+++ b/xbmc/addons/include/kodi_audioengine_types.h
@@ -106,11 +106,6 @@ extern "C" {
     unsigned int m_frames;
 
     /**
-     * The number of samples in one frame
-     */
-    unsigned int m_frameSamples;
-
-    /**
      * The size of one frame in bytes
      */
     unsigned int m_frameSize;
@@ -121,7 +116,6 @@ extern "C" {
       m_sampleRate = 0;
       m_encodedRate = 0;
       m_frames = 0;
-      m_frameSamples = 0;
       m_frameSize = 0;
       m_channelCount = 0;
 
@@ -142,7 +136,6 @@ extern "C" {
           m_sampleRate    != fmt->m_sampleRate    ||
           m_encodedRate   != fmt->m_encodedRate   ||
           m_frames        != fmt->m_frames        ||
-          m_frameSamples  != fmt->m_frameSamples  ||
           m_frameSize     != fmt->m_frameSize     ||
           m_channelCount  != fmt->m_channelCount)
       {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -265,8 +265,6 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   }
 
   m_format.m_frames         = m_min_frames / 2;
-
-  m_format.m_frameSamples   = m_format.m_frames * m_format.m_channelLayout.Count();
   format                    = m_format;
 
   // Force volume to 100% for passthrough

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.cpp
@@ -673,7 +673,6 @@ bool CAESinkDARWINIOS::Initialize(AEAudioFormat &format, std::string &device)
   m_audioSink->open(audioFormat);
 
   format.m_frames = m_audioSink->chunkSize();
-  format.m_frameSamples = format.m_frames * audioFormat.mChannelsPerFrame;
   // reset to the realised samplerate
   format.m_sampleRate = m_audioSink->getRealisedSampleRate();
   m_format = format;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -280,7 +280,6 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   format.m_channelLayout = m_channelLayout;
   m_encodedFormat = format.m_dataFormat;
   format.m_frames = uiFrameCount;
-  format.m_frameSamples = format.m_frames * format.m_channelLayout.Count();
   format.m_frameSize = (AE_IS_RAW(format.m_dataFormat) ? wfxex.Format.wBitsPerSample >> 3 : sizeof(float)) * format.m_channelLayout.Count();
   format.m_dataFormat = AE_IS_RAW(format.m_dataFormat) ? AE_FMT_S16NE : AE_FMT_FLOAT;
 
@@ -307,7 +306,6 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
   CLog::Log(LOGDEBUG, "  Channel Layout  : %s", ((std::string)format.m_channelLayout).c_str());
   CLog::Log(LOGDEBUG, "  Channel Mask    : %d", wfxex.dwChannelMask);
   CLog::Log(LOGDEBUG, "  Frames          : %d", format.m_frames);
-  CLog::Log(LOGDEBUG, "  Frame Samples   : %d", format.m_frameSamples);
   CLog::Log(LOGDEBUG, "  Frame Size      : %d", format.m_frameSize);
 
   return true;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPi.cpp
@@ -213,7 +213,6 @@ bool CAESinkPi::Initialize(AEAudioFormat &format, std::string &device)
   format.m_frameSize     = sample_size * channels;
   format.m_sampleRate    = std::max(8000U, std::min(192000U, format.m_sampleRate));
   format.m_frames        = format.m_sampleRate * AUDIO_PLAYBUFFER / NUM_OMX_BUFFERS;
-  format.m_frameSamples  = format.m_frames * channels;
 
   SetAudioProps(m_passthrough, GetChannelMap(format.m_channelLayout, m_passthrough));
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -310,7 +310,6 @@ bool CAESinkWASAPI::Initialize(AEAudioFormat &format, std::string &device)
   m_pAudioClient->GetBufferSize(&m_uiBufferLen);
 
   format.m_frames       = m_uiBufferLen;
-  format.m_frameSamples = format.m_frames * format.m_channelLayout.Count();
   m_format              = format;
   sinkRetFormat         = format.m_dataFormat;
 

--- a/xbmc/cores/AudioEngine/Sinks/test/TestAESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/test/TestAESinkDARWINOSX.cpp
@@ -141,7 +141,6 @@ AEAudioFormat getAC3AEFormat()
   srcFormat.m_encodedRate = 48000;
   srcFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
   srcFormat.m_frames = 0;
-  srcFormat.m_frameSamples = 0;
   srcFormat.m_frameSize = 0;
   return srcFormat;
 }
@@ -154,7 +153,6 @@ AEAudioFormat getStereo22050AEFormat()
   srcFormat.m_encodedRate = 0;
   srcFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
   srcFormat.m_frames = 0;
-  srcFormat.m_frameSamples = 0;
   srcFormat.m_frameSize = 0;
   return srcFormat;
 }
@@ -167,7 +165,6 @@ AEAudioFormat getStereo48000AEFormat()
   srcFormat.m_encodedRate = 0;
   srcFormat.m_channelLayout = AE_CH_LAYOUT_2_0;
   srcFormat.m_frames = 0;
-  srcFormat.m_frameSamples = 0;
   srcFormat.m_frameSize = 0;
   return srcFormat;
 }
@@ -180,7 +177,6 @@ AEAudioFormat getLPCM96000AEFormat()
   srcFormat.m_encodedRate = 0;
   srcFormat.m_channelLayout = AE_CH_LAYOUT_5_1;
   srcFormat.m_frames = 0;
-  srcFormat.m_frameSamples = 0;
   srcFormat.m_frameSize = 0;
   return srcFormat;
 }


### PR DESCRIPTION
Remove attribute from the sink's implementation after removal