### PR TITLE
AEUtils: Add Streamtypes to Enumeration output

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
@@ -49,6 +49,17 @@ CAEDeviceInfo::operator std::string()
   }
   ss << '\n';
 
+  ss << "m_streamTypes     : ";
+  for (AEDataTypeList::iterator itt = m_streamTypes.begin(); itt != m_streamTypes.end(); ++itt)
+  {
+    if (itt != m_streamTypes.begin())
+      ss << ',';
+    ss << CAEUtil::StreamTypeToStr(*itt);
+  }
+  if (m_streamTypes.empty())
+    ss << "No passthrough capabilities";
+  ss << '\n';
+
   return ss.str();
 }
 

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -222,6 +222,8 @@ const char* CAEUtil::DataFormatToStr(const enum AEDataFormat dataFormat)
     "AE_FMT_DOUBLE",
     "AE_FMT_FLOAT",
     
+    "AE_FMT_RAW",
+
     /* for passthrough streams and the like */
     "AE_FMT_AAC",
     "AE_FMT_AC3",

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -165,6 +165,34 @@ const unsigned int CAEUtil::DataFormatToDitherBits(const enum AEDataFormat dataF
     return 0;
 }
 
+const char* CAEUtil::StreamTypeToStr(const enum CAEStreamInfo::DataType dataType)
+{
+  switch (dataType)
+  {
+    case CAEStreamInfo::STREAM_TYPE_AC3:
+      return "STREAM_TYPE_AC3";
+    case CAEStreamInfo::STREAM_TYPE_DTSHD:
+      return "STREAM_TYPE_DTSHD";
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
+      return "STREAM_TYPE_DTSHD_CORE";
+    case CAEStreamInfo::STREAM_TYPE_DTS_1024:
+      return "STREAM_TYPE_DTS_1024";
+    case CAEStreamInfo::STREAM_TYPE_DTS_2048:
+      return "STREAM_TYPE_DTS_2048";
+    case CAEStreamInfo::STREAM_TYPE_DTS_512:
+      return "STREAM_TYPE_DTS_512";
+    case CAEStreamInfo::STREAM_TYPE_EAC3:
+      return "STREAM_TYPE_EAC3";
+    case CAEStreamInfo::STREAM_TYPE_MLP:
+      return "STREAM_TYPE_MLP";
+    case CAEStreamInfo::STREAM_TYPE_TRUEHD:
+      return "STREAM_TYPE_TRUEHD";
+
+    default:
+      return "STREAM_TYPE_NULL";
+  }
+}
+
 const char* CAEUtil::DataFormatToStr(const enum AEDataFormat dataFormat)
 {
   if (dataFormat < 0 || dataFormat >= AE_FMT_MAX)

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -151,6 +151,7 @@ public:
   static const unsigned int      DataFormatToUsedBits (const enum AEDataFormat dataFormat);
   static const unsigned int      DataFormatToDitherBits(const enum AEDataFormat dataFormat);
   static const char*             DataFormatToStr   (const enum AEDataFormat dataFormat);
+  static const char* StreamTypeToStr(const enum CAEStreamInfo::DataType dataType);
 
   /*! \brief convert a volume percentage (as a proportion) to a dB gain
    We assume a dB range of 60dB, i.e. assume that 0% volume corresponds


### PR DESCRIPTION
Looks like:

```
17:31:48 T:139787532458112  NOTICE:     Device 2
17:31:48 T:139787532458112  NOTICE:         m_deviceName      : alsa_output.pci-0000_00_03.0.hdmi-stereo-extra2
17:31:48 T:139787532458112  NOTICE:         m_displayName     : Internes Audio Digital Stereo (HDMI 3)
17:31:48 T:139787532458112  NOTICE:         m_displayNameExtra: HDMI / DisplayPort 3 (PULSEAUDIO)
17:31:48 T:139787532458112  NOTICE:         m_deviceType      : AE_DEVTYPE_IEC958
17:31:48 T:139787532458112  NOTICE:         m_channels        : FL,FR
17:31:48 T:139787532458112  NOTICE:         m_sampleRates     : 5512,8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000,384000
17:31:48 T:139787532458112  NOTICE:         m_dataFormats     : AE_FMT_U8,AE_FMT_S16NE,AE_FMT_S24NE3,AE_FMT_S24NE4,AE_FMT_S32NE,AE_FMT_FLOAT,AE_FMT_AAC
17:31:48 T:139787532458112  NOTICE:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_DTS_2048
17:31:48 T:139787532458112  NOTICE:     Device 3
17:31:48 T:139787532458112  NOTICE:         m_deviceName      : alsa_output.pci-0000_00_1b.0.analog-stereo
17:31:48 T:139787532458112  NOTICE:         m_displayName     : Internes Audio Analog Stereo
17:31:48 T:139787532458112  NOTICE:         m_displayNameExtra: Lautsprecher (PULSEAUDIO)
17:31:48 T:139787532458112  NOTICE:         m_deviceType      : AE_DEVTYPE_PCM
17:31:48 T:139787532458112  NOTICE:         m_channels        : FL,FR
17:31:48 T:139787532458112  NOTICE:         m_sampleRates     : 5512,8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000,384000
17:31:48 T:139787532458112  NOTICE:         m_dataFormats     : AE_FMT_U8,AE_FMT_S16NE,AE_FMT_S24NE3,AE_FMT_S24NE4,AE_FMT_S32NE,AE_FMT_FLOAT
17:31:48 T:139787532458112  NOTICE:         m_streamTypes     : No passthrough capabilities
```