### PR TITLE
DVDAudioCodecPassthrough: Set samplerate when creating StreamInfo

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2317,7 +2317,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
           framesToDelay = ret->pkt->max_nb_samples;
         if (m_mode == MODE_TRANSCODE)
         {
-          if (framesToDelay > m_encoderFormat.m_frames / 2)
+          if (framesToDelay > (int) (m_encoderFormat.m_frames / 2))
             framesToDelay = m_encoderFormat.m_frames;
           else
             framesToDelay = 0;
@@ -2339,7 +2339,7 @@ CSampleBuffer* CActiveAE::SyncStream(CActiveAEStream *stream)
         framesToSkip = buf->pkt->nb_samples;
       if (m_mode == MODE_TRANSCODE)
       {
-        if (framesToSkip > m_encoderFormat.m_frames / 2)
+        if (framesToSkip > (int) (m_encoderFormat.m_frames / 2))
           framesToSkip = buf->pkt->nb_samples;
         else
           framesToSkip = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -46,18 +46,22 @@ bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &op
   {
     case AV_CODEC_ID_AC3:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+      format.m_streamInfo.m_sampleRate = hints.samplerate;
       break;
 
     case AV_CODEC_ID_EAC3:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
+      format.m_streamInfo.m_sampleRate = hints.samplerate;
       break;
 
     case AV_CODEC_ID_DTS:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD;
+      format.m_streamInfo.m_sampleRate = hints.samplerate;
       break;
 
     case AV_CODEC_ID_TRUEHD:
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+      format.m_streamInfo.m_sampleRate = hints.samplerate;
       break;
 
     default:

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -409,7 +409,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn/* = true */, b
       si->m_prepareNextAtFrame = (int)((streamTotalTime - TIME_TO_CACHE_NEXT_FILE - m_defaultCrossfadeMS) * si->m_sampleRate / 1000.0f);
   }
 
-  if (m_currentStream && (m_currentStream->m_audioFormat.m_dataFormat == AE_FMT_RAW) || (si->m_audioFormat.m_dataFormat == AE_FMT_RAW))
+  if (m_currentStream && ((m_currentStream->m_audioFormat.m_dataFormat == AE_FMT_RAW) || (si->m_audioFormat.m_dataFormat == AE_FMT_RAW)))
   {
     m_currentStream->m_prepareTriggered = false;
     m_currentStream->m_waitOnDrain = true;


### PR DESCRIPTION
We need to take great care ... in passthrough case the m_StreamInfo should have _all_ the data we need - now let's test EAC3.