### PR TITLE
[videoplayer] Add lock for player creation

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -499,6 +499,11 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer, std::
       demuxer->GetStreamCodecName(stream->iId, codec);
       s.codec    = codec;
       s.channels = 0; // Default to 0. Overwrite if STREAM_AUDIO below.
+      if(stream->type == STREAM_VIDEO)
+      {
+        s.width = ((CDemuxStreamVideo*)stream)->iWidth;
+        s.height = ((CDemuxStreamVideo*)stream)->iHeight;
+      }
       if(stream->type == STREAM_AUDIO)
       {
         std::string type;
@@ -1502,6 +1507,13 @@ void CVideoPlayer::Process()
 
     // check if in a cut or commercial break that should be automatically skipped
     CheckAutoSceneSkip();
+
+    // update the player info for streams
+    if (m_player_status_timer.IsTimePast())
+    {
+      m_player_status_timer.Set(500);
+      UpdateStreamInfos();
+    }
   }
 }
 
@@ -3132,8 +3144,41 @@ int CVideoPlayer::GetSubtitle()
   return m_SelectionStreams.IndexOf(STREAM_SUBTITLE, *this);
 }
 
+void CVideoPlayer::UpdateStreamInfos()
+{
+  CSingleLock lock(m_SelectionStreams.m_section);
+  int streamId;
+  std::string retVal;
+
+  // video
+  streamId = GetVideoStream();
+
+  if (streamId > 0 && streamId < GetVideoStreamCount())
+  {
+    SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, streamId);
+    s.bitrate = m_VideoPlayerVideo->GetVideoBitrate();
+    s.aspect_ratio = m_renderManager.GetAspectRatio();
+    CRect viewRect;
+    m_renderManager.GetVideoRect(s.SrcRect, s.DestRect, viewRect);
+    s.stereo_mode = m_VideoPlayerVideo->GetStereoMode();
+    if (s.stereo_mode == "mono")
+      s.stereo_mode = "";
+  }
+
+  // audio
+  streamId = GetAudioStream();
+
+  if (streamId >= 0 && streamId < GetAudioStreamCount())
+  {
+    SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, streamId);
+    s.bitrate = m_VideoPlayerAudio->GetAudioBitrate();
+    s.channels = m_VideoPlayerAudio->GetAudioChannels();
+  }
+}
+
 void CVideoPlayer::GetSubtitleStreamInfo(int index, SPlayerSubtitleStreamInfo &info)
 {
+  CSingleLock lock(m_SelectionStreams.m_section);
   if (index < 0 || index > (int) GetSubtitleCount() - 1)
     return;
 
@@ -4339,37 +4384,12 @@ double CVideoPlayer::GetQueueTime()
 
 void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info)
 {
+  CSingleLock lock(m_SelectionStreams.m_section);
   if (streamId == CURRENT_STREAM)
     streamId = GetVideoStream();
 
-  if (streamId < 0 || streamId > GetAudioStreamCount() - 1)
+  if (streamId < 0 || streamId > GetVideoStreamCount() - 1)
     return;
-
-  if (streamId == GetVideoStream())
-  {
-    info.bitrate = m_VideoPlayerVideo->GetVideoBitrate();
-  }
-
-  std::string retVal;
-  if (m_pDemuxer)
-  {
-    CDemuxStreamVideo* stream = m_pDemuxer->GetStreamFromVideoId(streamId);
-    m_pDemuxer->GetStreamCodecName(stream->iId, retVal);
-
-    if (stream)
-    {
-      info.width  = stream->iWidth;
-      info.height = stream->iHeight;
-    }
-  }
-
-  info.videoCodecName = retVal;
-  info.videoAspectRatio = m_renderManager.GetAspectRatio();
-  CRect viewRect;
-  m_renderManager.GetVideoRect(info.SrcRect, info.DestRect, viewRect);
-  info.stereoMode = m_VideoPlayerVideo->GetStereoMode();
-  if (info.stereoMode == "mono")
-    info.stereoMode = "";
 
   SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, streamId);
   if (s.language.length() > 0)
@@ -4377,6 +4397,15 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info
 
   if (s.name.length() > 0)
     info.name = s.name;
+
+  info.bitrate = s.bitrate;
+  info.width = s.width;
+  info.height = s.height;
+  info.SrcRect = s.SrcRect;
+  info.DestRect = s.DestRect;
+  info.videoCodecName = s.codec;
+  info.videoAspectRatio = s.aspect_ratio;
+  info.stereoMode = s.stereo_mode;
 }
 
 int CVideoPlayer::GetSourceBitrate()
@@ -4389,26 +4418,12 @@ int CVideoPlayer::GetSourceBitrate()
 
 void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
 {
+  CSingleLock lock(m_SelectionStreams.m_section);
   if (index == CURRENT_STREAM)
     index = GetAudioStream();
 
   if (index < 0 || index > GetAudioStreamCount() - 1 )
     return;
-
-  if (index == GetAudioStream())
-  {
-    info.bitrate = m_VideoPlayerAudio->GetAudioBitrate();
-    info.channels = m_VideoPlayerAudio->GetAudioChannels();
-  }
-  else if (m_pDemuxer)
-  {
-    CDemuxStreamAudio* stream = m_pDemuxer->GetStreamFromAudioId(index);
-    if (stream)
-    {
-      info.bitrate = stream->iBitRate;
-      info.channels = stream->iChannels;
-    }
-  }
 
   SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, index);
   if(s.language.length() > 0)
@@ -4420,16 +4435,9 @@ void CVideoPlayer::GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info)
   if(s.type == STREAM_NONE)
     info.name += " (Invalid)";
 
-  if (m_pDemuxer)
-  {
-    CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_pDemuxer->GetStreamFromAudioId(index));
-    if (stream)
-    {
-      std::string codecName;
-      m_pDemuxer->GetStreamCodecName(stream->iId, codecName);
-      info.audioCodecName = codecName;
-    }
-  }
+  info.bitrate = s.bitrate;
+  info.channels = s.channels;
+  info.audioCodecName = s.codec;
 }
 
 int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string& subfilename)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -173,13 +173,19 @@ typedef struct SelectionStream
   int          id = 0;
   std::string  codec;
   int          channels = 0;
+  int          bitrate = 0;
+  int          width = 0;
+  int          height = 0;
+  CRect        SrcRect;
+  CRect        DestRect;
+  std::string  stereo_mode;
+  float        aspect_ratio = 0.0f;
 } SelectionStream;
 
 typedef std::vector<SelectionStream> SelectionStreams;
 
 class CSelectionStreams
 {
-  CCriticalSection m_section;
   SelectionStream  m_invalid;
 public:
   CSelectionStreams()
@@ -189,6 +195,7 @@ public:
     m_invalid.type = STREAM_NONE;
   }
   std::vector<SelectionStream> m_Streams;
+  CCriticalSection m_section;
 
   int              IndexOf (StreamType type, int source, int id) const;
   int              IndexOf (StreamType type, CVideoPlayer& p) const;
@@ -288,6 +295,7 @@ public:
   virtual void GetVideoStreamInfo(int streamId, SPlayerVideoStreamInfo &info);
   virtual bool GetStreamDetails(CStreamDetails &details);
   virtual void GetAudioStreamInfo(int index, SPlayerAudioStreamInfo &info);
+  virtual void UpdateStreamInfos();
 
   virtual std::string GetPlayerState();
   virtual bool SetPlayerState(const std::string& state);
@@ -530,4 +538,6 @@ protected:
   // omxplayer variables
   struct SOmxPlayerState m_OmxPlayerState;
   bool m_omxplayer_mode;            // using omxplayer acceleration
+
+  XbmcThreads::EndTime m_player_status_timer;
 };


### PR DESCRIPTION
As omxplayer can create and destroy the player (e.g. based on hardware codec support)
there is currently a thread safety issue.

Add a lock around player create/destroy to protect this.