### PR TITLE
[ae/osx] - restore old behavior for scoring pass through formats by p…

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -526,6 +526,13 @@ float AEDeviceEnumerationOSX::ScoreFormat(const AudioStreamBasicDescription &for
     if (formatDesc.mChannelsPerFrame != format.m_channelLayout.Count())
       return score;
     score += 5;
+
+    if (formatDesc.mFormatID == kAudioFormat60958AC3 ||
+        formatDesc.mFormatID == 'IAC3' ||
+        formatDesc.mFormatID == kAudioFormatAC3)
+    {
+      score += 1;
+    }
   }
   // non-passthrough, whatever works is fine
   else if (formatDesc.mFormatID == kAudioFormatLinearPCM)


### PR DESCRIPTION
…refering dedicated streams - fixes unit tests

Does anything speak against this? Because i wrote the unit tests for a reason (preventing regressions) and even if it might not be true i would not like to change the behavior of stream selection/scoring if possible.