### PR TITLE
[cmake] More work on Windows support

### DIFF
--- a/project/cmake/modules/FindCpluff.cmake
+++ b/project/cmake/modules/FindCpluff.cmake
@@ -1,26 +1,45 @@
-string(REPLACE ";" " " defines "${CMAKE_C_FLAGS} ${SYSTEM_DEFINES} -I${EXPAT_INCLUDE_DIR}")
-get_filename_component(expat_dir ${EXPAT_LIBRARY} PATH)
-set(ldflags "-L${expat_dir}")
-ExternalProject_ADD(libcpluff SOURCE_DIR ${CORE_SOURCE_DIR}/lib/cpluff
-                    PREFIX ${CORE_BUILD_DIR}/cpluff
-                    PATCH_COMMAND rm -f config.status
-                    UPDATE_COMMAND autoreconf -vif
-                    CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} ${CORE_SOURCE_DIR}/lib/cpluff/configure
-                                      --disable-nls
-                                      --enable-static
-                                      --disable-shared
-                                      --with-pic
-                                      --prefix=<INSTALL_DIR>
-                                      --host=${ARCH}
-                                      CFLAGS=${defines}
-                                      LDFLAGS=${ldflags})
+# - Builds Cpluff as external project
+# Once done this will define
+#
+# CPLUFF_FOUND - system has cpluff
+# CPLUFF_INCLUDE_DIRS - the cpluff include directories
+#
+# and link Kodi against the cpluff libraries.
+
+if(NOT WIN32)
+  string(REPLACE ";" " " defines "${CMAKE_C_FLAGS} ${SYSTEM_DEFINES} -I${EXPAT_INCLUDE_DIR}")
+  get_filename_component(expat_dir ${EXPAT_LIBRARY} PATH)
+  set(ldflags "-L${expat_dir}")
+  ExternalProject_Add(libcpluff SOURCE_DIR ${CORE_SOURCE_DIR}/lib/cpluff
+                      PREFIX ${CORE_BUILD_DIR}/cpluff
+                      PATCH_COMMAND rm -f config.status
+                      UPDATE_COMMAND autoreconf -vif
+                      CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} ${CORE_SOURCE_DIR}/lib/cpluff/configure
+                                        --disable-nls
+                                        --enable-static
+                                        --disable-shared
+                                        --with-pic
+                                        --prefix=<INSTALL_DIR>
+                                        --host=${ARCH}
+                                        CFLAGS=${defines}
+                                        LDFLAGS=${ldflags})
+  set(ldflags "${ldflags};-lexpat")
+  core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/lib/libcpluff.a
+                    system/libcpluff libcpluff extras "${ldflags}")
+  set(WRAP_FILES ${WRAP_FILES} PARENT_SCOPE)
+else()
+  ExternalProject_Add(libcpluff SOURCE_DIR ${CORE_SOURCE_DIR}/lib/cpluff
+                      PREFIX ${CORE_BUILD_DIR}/cpluff
+                      CONFIGURE_COMMAND ""
+                      # TODO: Building the project directly from lib/cpluff/libcpluff/win32/cpluff.vcxproj
+                      #       fails becaue it imports XBMC.defaults.props
+                      BUILD_COMMAND devenv /build ${CMAKE_BUILD_TYPE}
+                                           ${CORE_SOURCE_DIR}/project/VS2010Express/XBMC\ for\ Windows.sln
+                                           /project cpluff
+                      INSTALL_COMMAND "")
+  # TODO: core_link_library
+endif()
 
 set(CPLUFF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/include)
 set(CPLUFF_FOUND 1)
-
-set(ldflags "${ldflags};-lexpat")
-core_link_library(${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cpluff/lib/libcpluff.a
-                  system/libcpluff libcpluff extras "${ldflags}")
-set(WRAP_FILES ${WRAP_FILES} PARENT_SCOPE)
-
 mark_as_advanced(CPLUFF_INCLUDE_DIRS CPLUFF_FOUND)

--- a/project/cmake/modules/FindD3DX11Effects.cmake
+++ b/project/cmake/modules/FindD3DX11Effects.cmake
@@ -1,9 +1,10 @@
-# - Try to find D3DX11Effects
+# - Builds D3DX11Effects as external project
 # Once done this will define
 #
 # D3DX11EFFECTS_FOUND - system has D3DX11Effects
 # D3DX11EFFECTS_INCLUDE_DIRS - the D3DX11Effects include directories
-# D3DX11EFFECTS_LIBRARIES - the D3DX11Effects libraries
+#
+# and link Kodi against the D3DX11Effects libraries.
 
 include(ExternalProject)
 ExternalProject_Add(d3dx11effects

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -53,8 +53,6 @@ set(SOURCES AddonsDirectory.cpp
             ResourceDirectory.cpp
             ResourceFile.cpp
             RSSDirectory.cpp
-            SAPDirectory.cpp
-            SAPFile.cpp
             SFTPDirectory.cpp
             SFTPFile.cpp
             ShoutcastFile.cpp

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -20,6 +20,8 @@
 
 #include "DAVDirectory.h"
 
+#include <time.h>
+
 #include "DAVCommon.h"
 #include "DAVFile.h"
 #include "URL.h"

--- a/xbmc/win32/PlatformDefs.h
+++ b/xbmc/win32/PlatformDefs.h
@@ -75,16 +75,16 @@ typedef intptr_t      ssize_t;
 #define BMASK 0x000000ff
 #endif
 
+#if _MSC_VER < 1800
 #ifndef va_copy
 #define va_copy(dst, src) ((dst) = (src))
 #endif
 
-#if _MSC_VER < 1800
 #define lrint(x) ((x) >= 0 ? ((int)((x) + 0.5)) : ((int)((x) - 0.5)))
 #define llrint(x) ((x) >= 0 ? ((__int64)((x) + 0.5)) : ((__int64)((x) - 0.5)))
-#endif
 
 #define strtoll(p, e, b) _strtoi64(p, e, b)
+#endif
 
 extern "C" char * strptime(const char *buf, const char *fmt, struct tm *tm);
 extern "C" int strverscmp (const char *s1, const char *s2);


### PR DESCRIPTION
@FernetMenta: Last set of changes for this year ;) Hope it's fine for you if they come in smaller chunks.
This time, there are 2 commits that touch header files in order to fix implicit include order dependencies.
Not sure if they should go to the main Kodi repository directly.

@wsnipex: For some of the dependencies we'll need to use mingw/msys (if I'm not mistaken).
Do you have an idea how to use ExternalProject_Add with mingw?
For example in https://github.com/FernetMenta/xbmc/blob/master/project/cmake/modules/FindLibDvd.cmake.

Happy new year!
Christian