### PR TITLE
only try to substitute recording path if a recording is requested

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -112,12 +112,14 @@ bool CInputStream::Open(CFileItem &fileitem)
 {
   INPUTSTREAM props;
   props.m_nCountInfoValues = 0;
+  std::vector<std::string> values;
   for (auto &key : m_fileItemProps)
   {
     if (fileitem.GetProperty(key).isNull())
       continue;
     props.m_ListItemProperties[props.m_nCountInfoValues].m_strKey = key.c_str();
-    props.m_ListItemProperties[props.m_nCountInfoValues].m_strValue = fileitem.GetProperty(key).asString().c_str();
+    values.push_back(fileitem.GetProperty(key).asString());
+    props.m_ListItemProperties[props.m_nCountInfoValues].m_strValue = values.back().c_str();
     props.m_nCountInfoValues++;
   }
   props.m_strURL = fileitem.GetPath().c_str();


### PR DESCRIPTION
I know its not pat of inputstream directly.... but I want to be able to open file based streams