### PR TITLE
Load Inputstream addon only if extension matches / regexp for path comparision

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -20,7 +20,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
-
+#include "utils/RegExp.h"
 
 namespace ADDON
 {
@@ -74,6 +74,9 @@ bool CInputStream::Supports(CFileItem &fileitem)
   if (!match)
     return false;
 
+  if (!m_pStruct)
+    return true;
+
   std::string pathList;
   try
   {
@@ -91,21 +94,20 @@ bool CInputStream::Supports(CFileItem &fileitem)
   }
 
   match = false;
+
   for (auto &path : m_pathList)
   {
     if (path.empty())
       continue;
 
-    if (fileitem.GetPath().compare(0, path.length(), path) == 0)
+    CRegExp r(true, CRegExp::asciiOnly, path.c_str());
+    if (r.RegFind(path.c_str()) == 0 && r.GetFindLen() > 6)
     {
       match = true;
       break;
     }
   }
-  if (!match)
-    return false;
-
-  return true;
+  return match;
 }
 
 bool CInputStream::Open(CFileItem &fileitem)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -52,7 +52,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer
   {
     std::shared_ptr<ADDON::CInputStream> input(std::static_pointer_cast<ADDON::CInputStream>(addons[i]));
     ADDON::CInputStream* clone = new ADDON::CInputStream(*input);
-    ADDON_STATUS status = clone->Create();
+    ADDON_STATUS status = clone->Supports(fileitem) ? clone->Create() : ADDON_STATUS_PERMANENT_FAILURE;
     if (status == ADDON_STATUS_OK)
     {
       if (clone->Supports(fileitem))


### PR DESCRIPTION
Curl should be compiled with gzip option - is this assured?

mpd files could be large (5MB and more) and this option in combination with enabled gzip curl support speeds up starting time of videos significant.