### PR TITLE
Added addon callback to allow addons to set transfer options

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -274,6 +274,10 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_free_directory");
       if (XBMC_free_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+      XBMC_add_transfer_option = (bool(*)(void* HANDLE, void* CB, void* file, const char *name, const char *value))
+        dlsym(m_libXBMC_addon, "XBMC_add_transfer_option");
+      if (XBMC_add_transfer_option == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
       m_Callbacks = XBMC_register_me(m_Handle);
       return m_Callbacks != NULL;
     }
@@ -596,6 +600,16 @@ namespace ADDON
       return XBMC_free_directory(m_Handle, m_Callbacks, items, num_items);
     }
 
+    /*!
+    * @brief Adds options for stream transfer (curl e.g)
+    * @param name The name of the option
+    * @param value The value of the option
+    */
+    bool AddTransferOption(void* file, const char *name, const char *value)
+    {
+      return XBMC_add_transfer_option(m_Handle, m_Callbacks, file, name, value);
+    }
+
   protected:
     void* (*XBMC_register_me)(void *HANDLE);
     void (*XBMC_unregister_me)(void *HANDLE, void* CB);
@@ -628,6 +642,7 @@ namespace ADDON
     bool (*XBMC_remove_directory)(void *HANDLE, void* CB, const char* strPath);
     bool (*XBMC_get_directory)(void *HANDLE, void* CB, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
     void (*XBMC_free_directory)(void *HANDLE, void* CB, VFSDirEntry* items, unsigned int num_items);
+    bool(*XBMC_add_transfer_option)(void *HANDLE, void* CB, void* file, const char *name, const char *value);
   private:
     void *m_libXBMC_addon;
     void *m_Handle;

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -292,4 +292,13 @@ DLLEXPORT void XBMC_free_directory(void *hdl, void* cb, VFSDirEntry* items, unsi
   ((CB_AddOnLib*)cb)->FreeDirectory(((AddonCB*)hdl)->addonData, items, num_items);
 }
 
+DLLEXPORT bool XBMC_add_transfer_option(void *hdl, void* cb, void* file, const char *name, const char *value)
+{
+  if (cb == NULL)
+    return false;
+
+  return ((CB_AddOnLib*)cb)->AddTransferOption(((AddonCB*)hdl)->addonData, file, name, value);
+}
+
+
 };

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -71,6 +71,7 @@ typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath)
 typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
 typedef bool (*AddOnGetDirectory)(const void* addonData, const char *strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
 typedef void (*AddOnFreeDirectory)(const void* addonData, VFSDirEntry* items, unsigned int num_items);
+typedef bool(*AddOnAddTransferOption)(const void* addonData, void* file, const char *name, const char *value);
 
 typedef struct CB_AddOn
 {
@@ -104,6 +105,7 @@ typedef struct CB_AddOn
   AddOnRemoveDirectory    RemoveDirectory;
   AddOnGetDirectory       GetDirectory;
   AddOnFreeDirectory      FreeDirectory;
+  AddOnAddTransferOption  AddTransferOption;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -75,6 +75,7 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->RemoveDirectory    = RemoveDirectory;
   m_callbacks->GetDirectory       = GetDirectory;
   m_callbacks->FreeDirectory      = FreeDirectory;
+  m_callbacks->AddTransferOption  = AddTransferOption;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()
@@ -588,6 +589,11 @@ void CAddonCallbacksAddon::FreeDirectory(const void* addonData, VFSDirEntry* ite
     free(items[i].path);
   }
   delete[] items;
+}
+
+bool CAddonCallbacksAddon::AddTransferOption(const void* addonData, void* file, const char *name, const char *value)
+{
+  return false;
 }
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -68,6 +68,7 @@ public:
   static bool RemoveDirectory(const void* addonData, const char *strPath);
   static bool GetDirectory(const void* addondata, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
   static void FreeDirectory(const void* addondata, VFSDirEntry* items, unsigned int num_items);
+  static bool AddTransferOption(const void* addondata, void* file, const char *name, const char *value);
 
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */


### PR DESCRIPTION
This is just the framework for replacing | added options to an URL - if this is OK I would finalize this in CCurl.