### PR TITLE
Implementation of AddTransferOption() in CCurlFile

### DIFF
--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -593,6 +593,13 @@ void CAddonCallbacksAddon::FreeDirectory(const void* addonData, VFSDirEntry* ite
 
 bool CAddonCallbacksAddon::AddTransferOption(const void* addonData, void* file, const char *name, const char *value)
 {
+  CAddonCallbacks* helper = (CAddonCallbacks*)addonData;
+  if (!helper)
+    return false;
+
+  CFile* cfile = (CFile*)file;
+  if (cfile)
+    return cfile->AddTransferOption(name, value);
   return false;
 }
 

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -780,41 +780,8 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     if (!options.empty())
     {
       // set xbmc headers
-      for (std::map<std::string,std::string>::const_iterator it = options.begin(); it != options.end(); ++it)
-      {
-        std::string name = it->first; StringUtils::ToLower(name);
-        const std::string &value = it->second;
-
-        if (name == "auth")
-        {
-          m_httpauth = value;
-          StringUtils::ToLower(m_httpauth);
-          if(m_httpauth.empty())
-            m_httpauth = "any";
-        }
-        else if (name == "referer")
-          SetReferer(value);
-        else if (name == "user-agent")
-          SetUserAgent(value);
-        else if (name == "cookie")
-          SetCookie(value);
-        else if (name == "encoding")
-          SetContentEncoding(value);
-        else if (name == "noshout" && value == "true")
-          m_skipshout = true;
-        else if (name == "seekable" && value == "0")
-          m_seekable = false;
-        else if (name == "accept-charset")
-          SetAcceptCharset(value);
-        else if (name == "httpproxy")
-          SetStreamProxy(value, PROXY_HTTP);
-        else if (name == "sslcipherlist")
-          m_cipherlist = value;
-        else if (name == "connection-timeout")
-          m_connecttimeout = strtol(value.c_str(), NULL, 10);
-        else
-          SetRequestHeader(it->first, value);
-      }
+      for (std::map<std::string, std::string>::const_iterator it = options.begin(); it != options.end(); ++it)
+        AddTransferOption(it->first, it->second);
     }
   }
   
@@ -1844,4 +1811,42 @@ int CCurlFile::IoControl(EIoControl request, void* param)
     return m_seekable ? 1 : 0;
 
   return -1;
+}
+
+bool CCurlFile::AddTransferOption(const std::string &name, const std::string &value)
+{
+  std::string lowerName(name);
+  StringUtils::ToLower(lowerName);
+
+  if (lowerName == "auth")
+  {
+    m_httpauth = value;
+    StringUtils::ToLower(m_httpauth);
+    if (m_httpauth.empty())
+      m_httpauth = "any";
+  }
+  else if (lowerName == "referer")
+    SetReferer(value);
+  else if (lowerName == "user-agent")
+    SetUserAgent(value);
+  else if (lowerName == "cookie")
+    SetCookie(value);
+  else if (lowerName == "encoding")
+    SetContentEncoding(value);
+  else if (lowerName == "noshout" && value == "true")
+    m_skipshout = true;
+  else if (lowerName == "seekable" && value == "0")
+    m_seekable = false;
+  else if (lowerName == "accept-charset")
+    SetAcceptCharset(value);
+  else if (lowerName == "httpproxy")
+    SetStreamProxy(value, PROXY_HTTP);
+  else if (lowerName == "sslcipherlist")
+    m_cipherlist = value;
+  else if (lowerName == "connection-timeout")
+    m_connecttimeout = strtol(value.c_str(), NULL, 10);
+  else
+    SetRequestHeader(name, value);
+
+  return true;
 }

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -63,6 +63,7 @@ namespace XFILE
       virtual std::string GetContent()                           { return m_state->m_httpheader.GetValue("content-type"); }
       virtual int IoControl(EIoControl request, void* param);
       virtual std::string GetContentCharset(void)                { return GetServerReportedCharset(); }
+      virtual bool AddTransferOption(const std::string &name, const std::string &value);
 
       bool Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML);
       bool Get(const std::string& strURL, std::string& strHTML);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -909,6 +909,11 @@ std::string CFile::GetContentCharset(void)
   return m_pFile->GetContentCharset();
 }
 
+bool CFile::AddTransferOption(const char *name, const char *value)
+{
+  return m_pFile ? m_pFile->AddTransferOption(name, value):false;
+}
+
 ssize_t CFile::LoadFile(const std::string &filename, auto_buffer& outputBuffer)
 {
   const CURL pathToUrl(filename);

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -115,8 +115,8 @@ public:
   int GetChunkSize();
   std::string GetContentMimeType(void);
   std::string GetContentCharset(void);
+  bool AddTransferOption(const char *name, const char *value);
   ssize_t LoadFile(const std::string &filename, auto_buffer& outputBuffer);
-
 
   // will return a size, that is aligned to chunk size
   // but always greater or equal to the file's chunk size

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -131,6 +131,7 @@ public:
 
   virtual std::string GetContent()                           { return "application/octet-stream"; }
   virtual std::string GetContentCharset(void)                { return ""; }
+  virtual bool AddTransferOption(const std::string &name, const std::string &value) { return false; };
 };
 
 class CRedirectException


### PR DESCRIPTION
This is the final implementation in CCurlFile.
The deprecated solution using | is still supported