### PR TITLE
Curloptions

### DIFF
--- a/addons/library.xbmc.addon/libXBMC_addon.h
+++ b/addons/library.xbmc.addon/libXBMC_addon.h
@@ -37,8 +37,10 @@ typedef intptr_t      ssize_t;
 
 #if defined(BUILD_KODI_ADDON)
 	#include "p8-platform/windows/dlfcn-win32.h"
+  #include "IFileTypes.h"
 #else
 	#include "dlfcn-win32.h"
+  #include "filesystem/IFileTypes.h"
 #endif
 
 #define ADDON_DLL               "\\library.xbmc.addon\\libXBMC_addon" ADDON_HELPER_EXT
@@ -190,11 +192,11 @@ namespace ADDON
         dlsym(m_libXBMC_addon, "XBMC_get_dvd_menu_language");
       if (XBMC_get_dvd_menu_language == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_open_file = (void* (*)(void* HANDLE, void* CB, const char* strFileName, unsigned int flags, const char* strProtocolOptions))
+      XBMC_open_file = (void* (*)(void* HANDLE, void* CB, const char* strFileName, unsigned int flags))
         dlsym(m_libXBMC_addon, "XBMC_open_file");
       if (XBMC_open_file == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
-      XBMC_open_file_for_write = (void* (*)(void* HANDLE, void* CB, const char* strFileName, bool bOverWrite, const char* strProtocolOptions))
+      XBMC_open_file_for_write = (void* (*)(void* HANDLE, void* CB, const char* strFileName, bool bOverWrite))
         dlsym(m_libXBMC_addon, "XBMC_open_file_for_write");
       if (XBMC_open_file_for_write == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
@@ -229,6 +231,10 @@ namespace ADDON
       XBMC_get_file_length = (int64_t (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_get_file_length");
       if (XBMC_get_file_length == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_get_file_download_speed = (double(*)(void* HANDLE, void* CB, void* file))
+        dlsym(m_libXBMC_addon, "XBMC_get_file_download_speed");
+      if (XBMC_get_file_download_speed == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
       XBMC_close_file = (void (*)(void* HANDLE, void* CB, void* file))
         dlsym(m_libXBMC_addon, "XBMC_close_file");
@@ -273,6 +279,18 @@ namespace ADDON
       XBMC_free_directory = (void (*)(void* HANDLE, void* CB, VFSDirEntry* items, unsigned int num_items))
         dlsym(m_libXBMC_addon, "XBMC_free_directory");
       if (XBMC_free_directory == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_curl_create = (void* (*)(void *HANDLE, void* CB, const char* strURL))
+        dlsym(m_libXBMC_addon, "XBMC_curl_create");
+      if (XBMC_curl_create == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_curl_add_option = (bool (*)(void *HANDLE, void* CB, void *file, XFILE::CURLOPTIONTYPE type, const char* name, const char *value))
+        dlsym(m_libXBMC_addon, "XBMC_curl_add_option");
+      if (XBMC_curl_add_option == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
+      XBMC_curl_open = (bool (*)(void *HANDLE, void* CB, void *file, unsigned int flags))
+        dlsym(m_libXBMC_addon, "XBMC_curl_open");
+      if (XBMC_curl_open == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
       m_Callbacks = XBMC_register_me(m_Handle);
       return m_Callbacks != NULL;
@@ -374,9 +392,9 @@ namespace ADDON
      * @param flags The flags to pass. Documented in XBMC's File.h
      * @return A handle for the file, or NULL if it couldn't be opened.
      */
-    void* OpenFile(const char* strFileName, unsigned int flags, const char* strProtocolOptions=0)
+    void* OpenFile(const char* strFileName, unsigned int flags)
     {
-      return XBMC_open_file(m_Handle, m_Callbacks, strFileName, flags, strProtocolOptions);
+      return XBMC_open_file(m_Handle, m_Callbacks, strFileName, flags);
     }
 
     /*!
@@ -385,9 +403,9 @@ namespace ADDON
      * @param bOverWrite True to overwrite, false otherwise.
      * @return A handle for the file, or NULL if it couldn't be opened.
      */
-    void* OpenFileForWrite(const char* strFileName, bool bOverWrite, const char* strProtocolOptions=0)
+    void* OpenFileForWrite(const char* strFileName, bool bOverWrite)
     {
-      return XBMC_open_file_for_write(m_Handle, m_Callbacks, strFileName, bOverWrite, strProtocolOptions);
+      return XBMC_open_file_for_write(m_Handle, m_Callbacks, strFileName, bOverWrite);
     }
 
     /*!
@@ -480,6 +498,16 @@ namespace ADDON
     int64_t GetFileLength(void* file)
     {
       return XBMC_get_file_length(m_Handle, m_Callbacks, file);
+    }
+
+    /*!
+    * @brief Get the download speed of an open file if available.
+    * @param file The file to get the size for.
+    * @return The download speed in seconds.
+    */
+    double GetFileDownloadSpeed(void* file)
+    {
+      return XBMC_get_file_download_speed(m_Handle, m_Callbacks, file);
     }
 
     /*!
@@ -596,6 +624,37 @@ namespace ADDON
       return XBMC_free_directory(m_Handle, m_Callbacks, items, num_items);
     }
 
+    /*!
+    * @brief Create a Curl representation
+    * @param strURL the URL of the Type.
+    */
+    void* CURLCreate(const char* strURL)
+    {
+      return XBMC_curl_create(m_Handle, m_Callbacks, strURL);
+    }
+
+    /*!
+    * @brief Adds options to the curl file created with CURLCeate
+    * @param file file pointer to the file returned by CURLCeate
+    * @param type option type to set
+    * @param name name of the option
+    * @param value value of the option
+    */
+    bool CURLAddOption(void* file, XFILE::CURLOPTIONTYPE type, const char* name, const char * value)
+    {
+      return XBMC_curl_add_option(m_Handle, m_Callbacks, file, type, name, value);
+    }
+
+    /*!
+    * @brief Opens the curl file created with CURLCeate
+    * @param file file pointer to the file returned by CURLCeate
+    * @param flags one or more bitwise or combinded flags form XFILE
+    */
+    bool CURLOpen(void* file, unsigned int flags)
+    {
+      return XBMC_curl_open(m_Handle, m_Callbacks, file, flags);
+    }
+
   protected:
     void* (*XBMC_register_me)(void *HANDLE);
     void (*XBMC_unregister_me)(void *HANDLE, void* CB);
@@ -607,8 +666,8 @@ namespace ADDON
     char* (*XBMC_get_localized_string)(void *HANDLE, void* CB, int dwCode);
     char* (*XBMC_get_dvd_menu_language)(void *HANDLE, void* CB);
     void (*XBMC_free_string)(void *HANDLE, void* CB, char* str);
-    void* (*XBMC_open_file)(void *HANDLE, void* CB, const char* strFileName, unsigned int flags, const char* strProtocolOptions);
-    void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite, const char* strProtocolOptions);
+    void* (*XBMC_open_file)(void *HANDLE, void* CB, const char* strFileName, unsigned int flags);
+    void* (*XBMC_open_file_for_write)(void *HANDLE, void* CB, const char* strFileName, bool bOverWrite);
     ssize_t (*XBMC_read_file)(void *HANDLE, void* CB, void* file, void* lpBuf, size_t uiBufSize);
     bool (*XBMC_read_file_string)(void *HANDLE, void* CB, void* file, char *szLine, int iLineLength);
     ssize_t(*XBMC_write_file)(void *HANDLE, void* CB, void* file, const void* lpBuf, size_t uiBufSize);
@@ -617,6 +676,7 @@ namespace ADDON
     int (*XBMC_truncate_file)(void *HANDLE, void* CB, void* file, int64_t iSize);
     int64_t (*XBMC_get_file_position)(void *HANDLE, void* CB, void* file);
     int64_t (*XBMC_get_file_length)(void *HANDLE, void* CB, void* file);
+    double(*XBMC_get_file_download_speed)(void *HANDLE, void* CB, void* file);
     void (*XBMC_close_file)(void *HANDLE, void* CB, void* file);
     int (*XBMC_get_file_chunk_size)(void *HANDLE, void* CB, void* file);
     bool (*XBMC_file_exists)(void *HANDLE, void* CB, const char *strFileName, bool bUseCache);
@@ -628,6 +688,10 @@ namespace ADDON
     bool (*XBMC_remove_directory)(void *HANDLE, void* CB, const char* strPath);
     bool (*XBMC_get_directory)(void *HANDLE, void* CB, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
     void (*XBMC_free_directory)(void *HANDLE, void* CB, VFSDirEntry* items, unsigned int num_items);
+    void* (*XBMC_curl_create)(void *HANDLE, void* CB, const char* strURL);
+    bool (*XBMC_curl_add_option)(void *HANDLE, void* CB, void *file, XFILE::CURLOPTIONTYPE type, const char* name, const char *value);
+    bool (*XBMC_curl_open)(void *m_Handle, void *m_Callbacks, void *file, unsigned int flags);
+
   private:
     void *m_libXBMC_addon;
     void *m_Handle;

--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -124,20 +124,20 @@ DLLEXPORT void XBMC_free_string(void* hdl, void* cb, char* str)
   ((CB_AddOnLib*)cb)->FreeString(((AddonCB*)hdl)->addonData, str);
 }
 
-DLLEXPORT void* XBMC_open_file(void *hdl, void* cb, const char* strFileName, unsigned int flags, const char* strProtocolOptions)
+DLLEXPORT void* XBMC_open_file(void *hdl, void* cb, const char* strFileName, unsigned int flags)
 {
   if (cb == NULL)
     return NULL;
 
-  return ((CB_AddOnLib*)cb)->OpenFile(((AddonCB*)hdl)->addonData, strFileName, flags, strProtocolOptions);
+  return ((CB_AddOnLib*)cb)->OpenFile(((AddonCB*)hdl)->addonData, strFileName, flags);
 }
 
-DLLEXPORT void* XBMC_open_file_for_write(void *hdl, void* cb, const char* strFileName, bool bOverWrite, const char* strProtocolOptions)
+DLLEXPORT void* XBMC_open_file_for_write(void *hdl, void* cb, const char* strFileName, bool bOverWrite)
 {
   if (cb == NULL)
     return NULL;
 
-  return ((CB_AddOnLib*)cb)->OpenFileForWrite(((AddonCB*)hdl)->addonData, strFileName, bOverWrite, strProtocolOptions);
+  return ((CB_AddOnLib*)cb)->OpenFileForWrite(((AddonCB*)hdl)->addonData, strFileName, bOverWrite);
 }
 
 DLLEXPORT ssize_t XBMC_read_file(void *hdl, void* cb, void* file, void* lpBuf, size_t uiBufSize)
@@ -202,6 +202,14 @@ DLLEXPORT int64_t XBMC_get_file_length(void *hdl, void* cb, void* file)
     return 0;
 
   return ((CB_AddOnLib*)cb)->GetFileLength(((AddonCB*)hdl)->addonData, file);
+}
+
+DLLEXPORT double XBMC_get_file_download_speed(void *hdl, void* cb, void* file)
+{
+  if (cb == NULL)
+    return 0.0f;
+
+  return ((CB_AddOnLib*)cb)->GetFileDownloadSpeed(((AddonCB*)hdl)->addonData, file);
 }
 
 DLLEXPORT void XBMC_close_file(void *hdl, void* cb, void* file)
@@ -290,6 +298,30 @@ DLLEXPORT void XBMC_free_directory(void *hdl, void* cb, VFSDirEntry* items, unsi
     return;
 
   ((CB_AddOnLib*)cb)->FreeDirectory(((AddonCB*)hdl)->addonData, items, num_items);
+}
+
+DLLEXPORT void* XBMC_curl_create(void *hdl, void* cb, const char* strURL)
+{
+  if (cb == NULL)
+    return NULL;
+
+  return ((CB_AddOnLib*)cb)->CURLCreate(((AddonCB*)hdl)->addonData, strURL);
+}
+
+DLLEXPORT bool XBMC_curl_add_option(void *hdl, void* cb, void *file, XFILE::CURLOPTIONTYPE type, const char* name, const char *value)
+{
+  if (cb == NULL)
+    return NULL;
+
+  return ((CB_AddOnLib*)cb)->CURLAddOption(((AddonCB*)hdl)->addonData, file, type, name, value);
+}
+
+DLLEXPORT bool XBMC_curl_open(void *hdl, void* cb, void *file, unsigned int flags)
+{
+  if (cb == NULL)
+    return NULL;
+
+  return ((CB_AddOnLib*)cb)->CURLOpen(((AddonCB*)hdl)->addonData, file, flags);
 }
 
 };

--- a/project/cmake/installdata/addon-bindings.txt
+++ b/project/cmake/installdata/addon-bindings.txt
@@ -23,3 +23,4 @@ addons/library.xbmc.pvr/libXBMC_pvr.h
 addons/library.xbmc.codec/libXBMC_codec.h
 xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 xbmc/cores/AudioEngine/Utils/AEChannelData.h
+xbmc/filesystem/IFileTypes.h

--- a/xbmc/addons/AddonCallbacks.h
+++ b/xbmc/addons/AddonCallbacks.h
@@ -50,8 +50,8 @@ typedef char* (*AddOnGetLocalizedString)(const void* addonData, long dwCode);
 typedef char* (*AddOnGetDVDMenuLanguage)(const void* addonData);
 typedef void (*AddOnFreeString)(const void* addonData, char* str);
 
-typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, unsigned int flags, const char* strProtocolOptions);
-typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite, const char* strProtocolOptions);
+typedef void* (*AddOnOpenFile)(const void* addonData, const char* strFileName, unsigned int flags);
+typedef void* (*AddOnOpenFileForWrite)(const void* addonData, const char* strFileName, bool bOverWrite);
 typedef ssize_t (*AddOnReadFile)(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
 typedef bool (*AddOnReadFileString)(const void* addonData, void* file, char *szLine, int iLineLength);
 typedef ssize_t (*AddOnWriteFile)(const void* addonData, void* file, const void* lpBuf, size_t uiBufSize);
@@ -60,6 +60,7 @@ typedef int64_t (*AddOnSeekFile)(const void* addonData, void* file, int64_t iFil
 typedef int (*AddOnTruncateFile)(const void* addonData, void* file, int64_t iSize);
 typedef int64_t (*AddOnGetFilePosition)(const void* addonData, void* file);
 typedef int64_t (*AddOnGetFileLength)(const void* addonData, void* file);
+typedef double(*AddOnGetFileDownloadSpeed)(const void* addonData, void* file);
 typedef void (*AddOnCloseFile)(const void* addonData, void* file);
 typedef int (*AddOnGetFileChunkSize)(const void* addonData, void* file);
 typedef bool (*AddOnFileExists)(const void* addonData, const char *strFileName, bool bUseCache);
@@ -71,6 +72,9 @@ typedef bool (*AddOnDirectoryExists)(const void* addonData, const char *strPath)
 typedef bool (*AddOnRemoveDirectory)(const void* addonData, const char *strPath);
 typedef bool (*AddOnGetDirectory)(const void* addonData, const char *strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
 typedef void (*AddOnFreeDirectory)(const void* addonData, VFSDirEntry* items, unsigned int num_items);
+typedef void* (*AddOnCURLCreate)(const void* addonData, const char* strURL);
+typedef bool(*AddOnCURLAddOption)(const void* addonData, void* file, XFILE::CURLOPTIONTYPE type, const char* name, const char * value);
+typedef bool(*AddOnCURLOpen)(const void* addonData, void* file, unsigned int flags);
 
 typedef struct CB_AddOn
 {
@@ -83,27 +87,31 @@ typedef struct CB_AddOn
   AddOnGetDVDMenuLanguage GetDVDMenuLanguage;
   AddOnFreeString         FreeString;
 
-  AddOnOpenFile           OpenFile;
-  AddOnOpenFileForWrite   OpenFileForWrite;
-  AddOnReadFile           ReadFile;
-  AddOnReadFileString     ReadFileString;
-  AddOnWriteFile          WriteFile;
-  AddOnFlushFile          FlushFile;
-  AddOnSeekFile           SeekFile;
-  AddOnTruncateFile       TruncateFile;
-  AddOnGetFilePosition    GetFilePosition;
-  AddOnGetFileLength      GetFileLength;
-  AddOnCloseFile          CloseFile;
-  AddOnGetFileChunkSize   GetFileChunkSize;
-  AddOnFileExists         FileExists;
-  AddOnStatFile           StatFile;
-  AddOnDeleteFile         DeleteFile;
-  AddOnCanOpenDirectory   CanOpenDirectory;
-  AddOnCreateDirectory    CreateDirectory;
-  AddOnDirectoryExists    DirectoryExists;
-  AddOnRemoveDirectory    RemoveDirectory;
-  AddOnGetDirectory       GetDirectory;
-  AddOnFreeDirectory      FreeDirectory;
+  AddOnOpenFile               OpenFile;
+  AddOnOpenFileForWrite       OpenFileForWrite;
+  AddOnReadFile               ReadFile;
+  AddOnReadFileString         ReadFileString;
+  AddOnWriteFile              WriteFile;
+  AddOnFlushFile              FlushFile;
+  AddOnSeekFile               SeekFile;
+  AddOnTruncateFile           TruncateFile;
+  AddOnGetFilePosition        GetFilePosition;
+  AddOnGetFileLength          GetFileLength;
+  AddOnGetFileDownloadSpeed   GetFileDownloadSpeed;
+  AddOnCloseFile              CloseFile;
+  AddOnGetFileChunkSize       GetFileChunkSize;
+  AddOnFileExists             FileExists;
+  AddOnStatFile               StatFile;
+  AddOnDeleteFile             DeleteFile;
+  AddOnCanOpenDirectory       CanOpenDirectory;
+  AddOnCreateDirectory        CreateDirectory;
+  AddOnDirectoryExists        DirectoryExists;
+  AddOnRemoveDirectory        RemoveDirectory;
+  AddOnGetDirectory           GetDirectory;
+  AddOnFreeDirectory          FreeDirectory;
+  AddOnCURLCreate             CURLCreate;
+  AddOnCURLAddOption          CURLAddOption;
+  AddOnCURLOpen               CURLOpen;
 } CB_AddOnLib;
 
 typedef xbmc_codec_t (*CODECGetCodecByName)(const void* addonData, const char* strCodecName);

--- a/xbmc/addons/AddonCallbacksAddon.cpp
+++ b/xbmc/addons/AddonCallbacksAddon.cpp
@@ -64,6 +64,7 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->TruncateFile       = TruncateFile;
   m_callbacks->GetFilePosition    = GetFilePosition;
   m_callbacks->GetFileLength      = GetFileLength;
+  m_callbacks->GetFileDownloadSpeed = GetFileDownloadSpeed;
   m_callbacks->CloseFile          = CloseFile;
   m_callbacks->GetFileChunkSize   = GetFileChunkSize;
   m_callbacks->FileExists         = FileExists;
@@ -76,6 +77,10 @@ CAddonCallbacksAddon::CAddonCallbacksAddon(CAddon* addon)
   m_callbacks->RemoveDirectory    = RemoveDirectory;
   m_callbacks->GetDirectory       = GetDirectory;
   m_callbacks->FreeDirectory      = FreeDirectory;
+
+  m_callbacks->CURLCreate         = CURLCreate;
+  m_callbacks->CURLAddOption      = CURLAddOption;
+  m_callbacks->CURLOpen           = CURLOpen;
 }
 
 CAddonCallbacksAddon::~CAddonCallbacksAddon()
@@ -305,40 +310,28 @@ void CAddonCallbacksAddon::FreeString(const void* addonData, char* str)
   free(str);
 }
 
-void* CAddonCallbacksAddon::OpenFile(const void* addonData, const char* strFileName, unsigned int flags, const char* strPotocolOptions)
+void* CAddonCallbacksAddon::OpenFile(const void* addonData, const char* strFileName, unsigned int flags)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)
     return NULL;
 
   CFile* file = new CFile;
-
-  CURL url(strFileName);
-  
-  if (strPotocolOptions)
-    url.SetProtocolOptions(strPotocolOptions);
-  
-  if (file->Open(url, flags))
+  if (file->Open(strFileName, flags))
     return ((void*)file);
 
   delete file;
   return NULL;
 }
 
-void* CAddonCallbacksAddon::OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite, const char* strPotocolOptions)
+void* CAddonCallbacksAddon::OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite)
 {
   CAddonCallbacks* helper = (CAddonCallbacks*) addonData;
   if (!helper)
     return NULL;
 
   CFile* file = new CFile;
-  
-  CURL url(strFileName);
-
-  if (strPotocolOptions)
-    url.SetProtocolOptions(strPotocolOptions);
-
-  if (file->OpenForWrite(url, bOverwrite))
+  if (file->OpenForWrite(strFileName, bOverwrite))
     return ((void*)file);
 
   delete file;
@@ -447,6 +440,19 @@ int64_t CAddonCallbacksAddon::GetFileLength(const void* addonData, void* file)
     return 0;
 
   return cfile->GetLength();
+}
+
+double CAddonCallbacksAddon::GetFileDownloadSpeed(const void* addonData, void* file)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*)addonData;
+  if (!helper)
+    return 0;
+
+  CFile* cfile = (CFile*)file;
+  if (!cfile)
+    return 0;
+
+  return cfile->GetDownloadSpeed();
 }
 
 void CAddonCallbacksAddon::CloseFile(const void* addonData, void* file)
@@ -601,6 +607,47 @@ void CAddonCallbacksAddon::FreeDirectory(const void* addonData, VFSDirEntry* ite
     free(items[i].path);
   }
   delete[] items;
+}
+
+void* CAddonCallbacksAddon::CURLCreate(const void* addonData, const char* strURL)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*)addonData;
+  if (!helper)
+    return nullptr;
+
+  CFile* file = new CFile;
+  if (file->CURLCreate(strURL))
+    return ((void*)file);
+
+  delete file;
+
+  return nullptr;
+}
+
+bool CAddonCallbacksAddon::CURLAddOption(const void* addonData, void* file, XFILE::CURLOPTIONTYPE type, const char* name, const char * value)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*)addonData;
+  if (!helper)
+    return 0;
+
+  CFile* cfile = (CFile*)file;
+  if (!cfile)
+    return 0;
+
+  return cfile->CURLAddOption(type, name, value);
+}
+
+bool CAddonCallbacksAddon::CURLOpen(const void* addonData, void* file, unsigned int flags)
+{
+  CAddonCallbacks* helper = (CAddonCallbacks*)addonData;
+  if (!helper)
+    return 0;
+
+  CFile* cfile = (CFile*)file;
+  if (!cfile)
+    return 0;
+
+  return cfile->CURLOpen(flags);
 }
 
 }; /* namespace ADDON */

--- a/xbmc/addons/AddonCallbacksAddon.h
+++ b/xbmc/addons/AddonCallbacksAddon.h
@@ -47,8 +47,8 @@ public:
   static void FreeString(const void* addonData, char* str);
 
   // file operations
-  static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags, const char* strProtocolOptions);
-  static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite, const char* strProtocolOptions);
+  static void* OpenFile(const void* addonData, const char* strFileName, unsigned int flags);
+  static void* OpenFileForWrite(const void* addonData, const char* strFileName, bool bOverwrite);
   static ssize_t ReadFile(const void* addonData, void* file, void* lpBuf, size_t uiBufSize);
   static bool ReadFileString(const void* addonData, void* file, char *szLine, int iLineLength);
   static ssize_t WriteFile(const void* addonData, void* file, const void* lpBuf, size_t uiBufSize);
@@ -57,6 +57,7 @@ public:
   static int TruncateFile(const void* addonData, void* file, int64_t iSize);
   static int64_t GetFilePosition(const void* addonData, void* file);
   static int64_t GetFileLength(const void* addonData, void* file);
+  static double GetFileDownloadSpeed(const void* addonData, void* file);
   static void CloseFile(const void* addonData, void* file);
   static int GetFileChunkSize(const void* addonData, void* file);
   static bool FileExists(const void* addonData, const char *strFileName, bool bUseCache);
@@ -68,6 +69,9 @@ public:
   static bool RemoveDirectory(const void* addonData, const char *strPath);
   static bool GetDirectory(const void* addondata, const char* strPath, const char* mask, VFSDirEntry** items, unsigned int* num_items);
   static void FreeDirectory(const void* addondata, VFSDirEntry* items, unsigned int num_items);
+  static void* CURLCreate(const void* addonData, const char* strURL);
+  static bool CURLAddOption(const void* addonData, void* curl, XFILE::CURLOPTIONTYPE type, const char* name, const char * value);
+  static bool CURLOpen(const void* addonData, void* curl, unsigned int flags);
 
 private:
   CB_AddOnLib  *m_callbacks; /*!< callback addresses */

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -29,3 +29,4 @@ BINDINGS+=addons/library.xbmc.codec/libXBMC_codec.h
 BINDINGS+=addons/library.kodi.inputstream/libKODI_inputstream.h
 BINDINGS+=xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 BINDINGS+=xbmc/cores/AudioEngine/Utils/AEChannelData.h
+BINDINGS+=xbmc/filesystem/IFileTypes.h

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1851,3 +1851,10 @@ int CCurlFile::IoControl(EIoControl request, void* param)
 
   return -1;
 }
+
+double CCurlFile::GetDownloadSpeed()
+{
+  double res = 0.0f;
+  g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_SPEED_DOWNLOAD, &res);
+  return res;
+}

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -63,6 +63,7 @@ namespace XFILE
       virtual std::string GetContent()                           { return m_state->m_httpheader.GetValue("content-type"); }
       virtual int IoControl(EIoControl request, void* param);
       virtual std::string GetContentCharset(void)                { return GetServerReportedCharset(); }
+      virtual double GetDownloadSpeed();
 
       bool Post(const std::string& strURL, const std::string& strPostData, std::string& strHTML);
       bool Get(const std::string& strURL, std::string& strHTML);

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -31,7 +31,6 @@
 #include "utils/URIUtils.h"
 #include "utils/BitstreamStats.h"
 #include "Util.h"
-#include "URL.h"
 #include "utils/StringUtils.h"
 
 #include "commons/Exception.h"
@@ -209,6 +208,47 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
 }
 
 //*********************************************************************************************
+
+bool CFile::CURLCreate(const std::string &url)
+{
+  m_curl.Parse(url);
+  return true;
+}
+
+bool CFile::CURLAddOption(XFILE::CURLOPTIONTYPE type, const char* name, const char * value)
+{
+  switch (type){
+  case XFILE::CURL_OPTION_CREDENTIALS:
+  {
+    m_curl.SetUserName(name);
+    m_curl.SetPassword(value);
+    break;
+  }
+  case XFILE::CURL_OPTION_PROTOCOL:
+  case XFILE::CURL_OPTION_HEADER:
+  {
+    m_curl.SetProtocolOption(name, value);
+    break;
+  }
+  case XFILE::CURL_OPTION_OPTION:
+  {
+    m_curl.SetOption(name, value);
+    break;
+  }
+  default:
+    return false;
+  }
+  return true;
+}
+
+bool CFile::CURLOpen(unsigned int flags)
+{
+  if (flags & XFILE::READ_AFTER_WRITE)
+    return OpenForWrite(m_curl, true);
+  else
+    return Open(m_curl, flags);
+}
+
 bool CFile::Open(const std::string& strFileName, const unsigned int flags)
 {
   const CURL pathToUrl(strFileName);
@@ -221,18 +261,17 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
   try
   {
     bool bPathInCache;
-    CURL url2(URIUtils::SubstitutePath(file));
-    if (url2.IsProtocol("apk"))
+
+    CURL url(URIUtils::SubstitutePath(file)), url2(url);
+
+    if (url2.IsProtocol("apk") || url2.IsProtocol("zip") )
       url2.SetOptions("");
-    if (url2.IsProtocol("zip"))
-      url2.SetOptions("");
+
     if (!g_directoryCache.FileExists(url2.Get(), bPathInCache) )
     {
       if (bPathInCache)
         return false;
     }
-
-    CURL url(URIUtils::SubstitutePath(file));
 
     if (!(m_flags & READ_NO_CACHE))
     {
@@ -247,8 +286,8 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
         return m_pFile->Open(url);
       }
     }
-
     m_pFile = CFileFactory::CreateLoader(url);
+
     if (!m_pFile)
       return false;
 
@@ -333,6 +372,7 @@ bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
     CURL url = URIUtils::SubstitutePath(file);
 
     m_pFile = CFileFactory::CreateLoader(url);
+
     if (m_pFile && m_pFile->OpenForWrite(url, bOverWrite))
     {
       // add this file to our directory cache (if it's stored)
@@ -977,6 +1017,13 @@ ssize_t CFile::LoadFile(const CURL& file, auto_buffer& outputBuffer)
   outputBuffer.resize(total_read);
 
   return total_read;
+}
+
+double CFile::GetDownloadSpeed()
+{
+  if (m_pFile)
+    return m_pFile->GetDownloadSpeed();
+  return 0.0f;
 }
 
 //*********************************************************************************************

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -35,9 +35,9 @@
 #include "utils/auto_buffer.h"
 #include "IFileTypes.h"
 #include "PlatformDefs.h"
+#include "URL.h"
 
 class BitstreamStats;
-class CURL;
 
 namespace XFILE
 {
@@ -52,27 +52,6 @@ public:
   virtual ~IFileCallback() {};
 };
 
-/* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
-#define READ_TRUNCATED    0x01
-
-/* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
-#define READ_CHUNKED      0x02
-
-/* use cache to access this file */
-#define READ_CACHED       0x04
-
-/* open without caching. regardless to file type. */
-#define READ_NO_CACHE     0x08
-
-/* calcuate bitrate for file while reading */
-#define READ_BITRATE      0x10
-
-/* indicate to the caller we will seek between multiple streams in the file frequently */
-#define READ_MULTI_STREAM 0x20
-
-/* indicate to the caller file is audio and/or video (and e.g. may grow) */
-#define READ_AUDIO_VIDEO  0x40
-
 class CFileStreamBuffer;
 
 class CFile
@@ -80,6 +59,10 @@ class CFile
 public:
   CFile();
   ~CFile();
+
+  bool CURLCreate(const std::string &url);
+  bool CURLAddOption(XFILE::CURLOPTIONTYPE type, const char* name, const char * value);
+  bool CURLOpen(unsigned int flags);
 
   bool Open(const CURL& file, const unsigned int flags = 0);
   bool OpenForWrite(const CURL& file, bool bOverWrite = false);
@@ -186,12 +169,14 @@ public:
   static bool Rename(const std::string& strFileName, const std::string& strNewFileName);
   static bool Copy(const std::string& strFileName, const std::string& strDest, XFILE::IFileCallback* pCallback = NULL, void* pContext = NULL);
   static bool SetHidden(const std::string& fileName, bool hidden);
+  double GetDownloadSpeed();
 
 private:
-  unsigned int m_flags;
-  IFile* m_pFile;
-  CFileStreamBuffer* m_pBuffer;
-  BitstreamStats* m_bitStreamStats;
+  unsigned int        m_flags;
+  CURL                m_curl;
+  IFile*              m_pFile;
+  CFileStreamBuffer*  m_pBuffer;
+  BitstreamStats*     m_bitStreamStats;
 };
 
 // streambuf for file io, only supports buffered input currently

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -120,6 +120,7 @@ public:
    * It can also be used to indicate a file system is non buffered *
    * but accepts any read size, have it return the value 1         */
   virtual int  GetChunkSize() {return 0;}
+  virtual double GetDownloadSpeed(){ return 0.0f; };
 
   virtual bool SkipNext(){return false;}
 

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -25,6 +25,30 @@
 namespace XFILE
 {
 
+/* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
+  static const unsigned int READ_TRUNCATED = 0x01;
+
+/* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
+  static const unsigned int READ_CHUNKED = 0x02;
+
+/* use cache to access this file */
+  static const unsigned int READ_CACHED = 0x04;
+
+/* open without caching. regardless to file type. */
+  static const unsigned int READ_NO_CACHE = 0x08;
+
+/* calcuate bitrate for file while reading */
+  static const unsigned int READ_BITRATE = 0x10;
+
+/* indicate to the caller we will seek between multiple streams in the file frequently */
+  static const unsigned int READ_MULTI_STREAM = 0x20;
+
+/* indicate to the caller file is audio and/or video (and e.g. may grow) */
+  static const unsigned int READ_AUDIO_VIDEO = 0x40;
+
+/* indicate that caller will do write operations before reading  */
+  static const unsigned int READ_AFTER_WRITE = 0x80;
+
 struct SNativeIoControl
 {
   unsigned long int   request;
@@ -46,5 +70,13 @@ typedef enum {
   IOCTRL_CACHE_SETRATE = 4, /**< unsigned int with speed limit for caching in bytes per second */
   IOCTRL_SET_CACHE    = 8, /** <CFileCache */
 } EIoControl;
+
+enum CURLOPTIONTYPE
+{
+  CURL_OPTION_OPTION,     /**< Set a general option   */
+  CURL_OPTION_PROTOCOL,   /**< Set a protocol option  */
+  CURL_OPTION_CREDENTIALS,/**< Set User and password  */
+  CURL_OPTION_HEADER      /**< Add a Header           */
+};
 
 }

--- a/xbmc/interfaces/legacy/File.h
+++ b/xbmc/interfaces/legacy/File.h
@@ -51,7 +51,7 @@ namespace XBMCAddon
         if (mode && strncmp(mode, "w", 1) == 0)
           file->OpenForWrite(filepath,true);
         else
-          file->Open(filepath, READ_NO_CACHE);
+          file->Open(filepath, XFILE::READ_NO_CACHE);
       }
 
       inline ~File() { delete file; }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -771,7 +771,7 @@ int CWebServer::CreateFileDownloadResponse(const std::shared_ptr<IHTTPRequestHan
   std::shared_ptr<XFILE::CFile> file = std::make_shared<XFILE::CFile>();
   std::string filePath = handler->GetResponseFile();
 
-  if (!file->Open(filePath, READ_NO_CACHE))
+  if (!file->Open(filePath, XFILE::READ_NO_CACHE))
   {
     CLog::Log(LOGERROR, "WebServer: Failed to open %s", filePath.c_str());
     return SendErrorResponse(request.connection, MHD_HTTP_NOT_FOUND, request.method);

--- a/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPFileHandler.cpp
@@ -80,7 +80,7 @@ void CHTTPFileHandler::SetFile(const std::string& file, int responseStatus)
 
     // determine the last modified date
     XFILE::CFile fileObj;
-    if (!fileObj.Open(m_url, READ_NO_CACHE))
+    if (!fileObj.Open(m_url, XFILE::READ_NO_CACHE))
     {
       m_response.type = HTTPError;
       m_response.status = MHD_HTTP_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
This implementation enables addon developers to fill an CCurl struct using three callback functions
- CURLCreate: Creates an instance of CFile and initializes an CCURL member
- CURLAddOption lets the developer set CURL options  (options / credentials..)
- CURLOpen finally calles open on the underlying stream

Furthermore CURLINFO_SPEED_DOWNLOAD is implemented

Moving XFILE constants (READ_NO_CACHE...) to IFileTypes.h and adding this file to the addon-bindings enable developers to use these constants by including this file in the addon.