### PR TITLE
fixup! RPi: Fixup move of videosync to windowing

### DIFF
--- a/xbmc/windowing/egl/CMakeLists.txt
+++ b/xbmc/windowing/egl/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 if(MMAL_FOUND)
   list(APPEND SOURCES EGLNativeTypeRaspberryPI.cpp)
   list(APPEND HEADERS EGLNativeTypeRaspberryPI.h)
+  list(APPEND SOURCES VideoSyncPi.cpp)
+  list(APPEND HEADERS VideoSyncPi.h)
 endif()
 
 if(IMX_FOUND)

--- a/xbmc/windowing/egl/VideoSyncPi.cpp
+++ b/xbmc/windowing/egl/VideoSyncPi.cpp
@@ -22,7 +22,7 @@
 
 #if defined(TARGET_RASPBERRY_PI)
 
-#include "windowing/VideoSyncPi.h"
+#include "VideoSyncPi.h"
 #include "guilib/GraphicContext.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/TimeUtils.h"
@@ -68,6 +68,12 @@ float CVideoSyncPi::GetFps()
 void CVideoSyncPi::OnResetDisplay()
 {
   m_abort = true;
+}
+
+void CVideoSyncPi::RefreshChanged()
+{
+  if (m_fps != g_graphicsContext.GetFPS())
+    m_abort = true;
 }
 
 #endif

--- a/xbmc/windowing/egl/VideoSyncPi.h
+++ b/xbmc/windowing/egl/VideoSyncPi.h
@@ -27,12 +27,13 @@
 class CVideoSyncPi : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncPi(CVideoReferenceClock *clock) : CVideoSync(clock) {};
+  CVideoSyncPi(void *clock) : CVideoSync(clock) {};
   virtual bool Setup(PUPDATECLOCK func);
   virtual void Run(std::atomic<bool>& stop);
   virtual void Cleanup();
   virtual float GetFps();
   virtual void OnResetDisplay();
+  virtual void RefreshChanged();
 
 private:
   volatile bool m_abort;

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -32,6 +32,7 @@
 #include "settings/DisplaySettings.h"
 #include "guilib/DispResource.h"
 #include "threads/SingleLock.h"
+#include "VideoSyncPi.h"
 #ifdef HAS_IMXVPU
 // This has to go into another header file
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecIMX.h"
@@ -555,5 +556,16 @@ bool CWinSystemEGL::ClampToGUIDisplayLimits(int &width, int &height)
   height = height > m_nHeight ? m_nHeight : height;
   return true;
 }
+
+std::unique_ptr<CVideoSync> CWinSystemEGL::GetVideoSync(void *clock)
+{
+#if defined(TARGET_RASPBERRY_PI)
+  std::unique_ptr<CVideoSync> pVSync(new CVideoSyncPi(clock));
+  return pVSync;
+#else
+  return nullptr;
+#endif
+}
+
 
 #endif

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -69,6 +69,9 @@ public:
 
   EGLDisplay    GetEGLDisplay();
   EGLContext    GetEGLContext();
+
+  // videosync
+  virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 protected:
   virtual void  PresentRenderImpl(bool rendered);
   virtual void  SetVSyncImpl(bool enable);


### PR DESCRIPTION
Previous version was just compiling but not actually plumbed in.
This seems to be active.