### PR TITLE
Fix side effects on function parameter

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -413,7 +413,7 @@ bool CApplication::Create(const CAppParamParser &params)
   // TODO
   // some of the serives depend on the WinSystem :(
   std::unique_ptr<CWinSystemBase> winSystem = CWinSystemBase::CreateWinSystem();
-  m_ServiceManager->SetWinSystem(winSystem);
+  m_ServiceManager->SetWinSystem(std::move(winSystem));
   
   if (!m_ServiceManager->InitStageOne())
   {
@@ -772,7 +772,7 @@ bool CApplication::DestroyWindow()
 {
   bool ret = CServiceBroker::GetWinSystem().DestroyWindow();
   std::unique_ptr<CWinSystemBase> winSystem;
-  m_ServiceManager->SetWinSystem(winSystem);
+  m_ServiceManager->SetWinSystem(std::move(winSystem));
   return ret;
 }
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -331,9 +331,9 @@ CWinSystemBase &CServiceManager::GetWinSystem()
   return *m_winSystem.get();
 }
 
-void CServiceManager::SetWinSystem(std::unique_ptr<CWinSystemBase> &winSystem)
+void CServiceManager::SetWinSystem(std::unique_ptr<CWinSystemBase> winSystem)
 {
-  m_winSystem.reset(winSystem.release());
+  m_winSystem = std::move(winSystem);
 }
 
 // deleters for unique_ptr

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -133,7 +133,7 @@ public:
   CFileExtensionProvider &GetFileExtensionProvider();
 
   CWinSystemBase &GetWinSystem();
-  void SetWinSystem(std::unique_ptr<CWinSystemBase> &winSystem);
+  void SetWinSystem(std::unique_ptr<CWinSystemBase> winSystem);
 
 protected:
   struct delete_dataCacheCore

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -124,7 +124,7 @@ void TestBasicEnvironment::SetUp()
   CServiceBroker::GetSettings().Initialize();
 
   std::unique_ptr<CWinSystemBase> winSystem = CWinSystemBase::CreateWinSystem();
-  g_application.m_ServiceManager->SetWinSystem(winSystem);
+  g_application.m_ServiceManager->SetWinSystem(std::move(winSystem));
 
   if (!g_application.m_ServiceManager->InitStageTwo(CAppParamParser()))
     exit(1);


### PR DESCRIPTION
For https://github.com/xbmc/xbmc/pull/13047

The current code modifies its parameter, but this behavior is not documented. This change uses the move operator to invalidate parameters as they're passed to the function.

Compilation tested on OSX, traveling now so don't got other systems to test.