### PR TITLE
gbm: register optionals

### DIFF
--- a/xbmc/windowing/gbm/CMakeLists.txt
+++ b/xbmc/windowing/gbm/CMakeLists.txt
@@ -1,11 +1,13 @@
-set(SOURCES GLContextEGL.cpp
+set(SOURCES OptionalsReg.cpp
+            GLContextEGL.cpp
             WinSystemGbm.cpp
             GBMUtils.cpp
             DRMUtils.cpp
             DRMLegacy.cpp
             DRM.cpp)
 
-set(HEADERS GLContextEGL.h
+set(HEADERS OptionalsReg.h
+            GLContextEGL.h
             WinSystemGbm.h
             GBMUtils.h
             DRMUtils.h

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -1,0 +1,163 @@
+/*
+ *      Copyright (C) 2005-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "OptionalsReg.h"
+
+//-----------------------------------------------------------------------------
+// VAAPI
+//-----------------------------------------------------------------------------
+#if defined (HAVE_LIBVA)
+#include <va/va_drm.h>
+#include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
+#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
+
+class CVaapiProxy : public VAAPI::IVaapiWinSystem
+{
+public:
+  CVaapiProxy() = default;
+  VADisplay GetVADisplay() override;
+  void *GetEGLDisplay() override { return eglDisplay; };
+
+  VADisplay vaDpy;
+  void *eglDisplay;
+};
+
+VADisplay CVaapiProxy::GetVADisplay()
+{
+  int const buf_size{128};
+  char name[buf_size];
+  int fd{-1};
+
+  // 128 is the start of the NUM in renderD<NUM>
+  for (int i = 128; i < (128 + 16); i++)
+  {
+    snprintf(name, buf_size, "/dev/dri/renderD%u", i);
+
+    fd = open(name, O_RDWR);
+
+    if (fd < 0)
+    {
+      continue;
+    }
+
+    auto display = vaGetDisplayDRM(fd);
+
+    if (display != nullptr)
+    {
+      return display;
+    }
+  }
+
+  return nullptr;
+}
+
+CVaapiProxy* GBM::VaapiProxyCreate()
+{
+  return new CVaapiProxy();
+}
+
+void GBM::VaapiProxyDelete(CVaapiProxy *proxy)
+{
+  delete proxy;
+}
+
+void GBM::VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy)
+{
+  proxy->vaDpy = proxy->GetVADisplay();
+  proxy->eglDisplay = eglDpy;
+}
+
+void GBM::VAAPIRegister(CVaapiProxy *winSystem, bool hevc)
+{
+  VAAPI::CDecoder::Register(winSystem, hevc);
+}
+
+void GBM::VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc)
+{
+  CRendererVAAPI::Register(winSystem, winSystem->vaDpy, winSystem->eglDisplay, general, hevc);
+}
+
+#else
+
+class CVaapiProxy
+{
+};
+
+CVaapiProxy* VaapiProxyCreate()
+{
+  return nullptr;
+}
+
+void GBM::VaapiProxyDelete(CVaapiProxy *proxy)
+{
+}
+
+void GBM::VaapiProxyConfig(CVaapiProxy *proxy, void *dpy, void *eglDpy)
+{
+
+}
+
+void GBM::RegisterVAAPI(CVaapiProxy *winSystem, bool hevc)
+{
+
+}
+
+void GBM::RegisterVAAPIRender(CVaapiProxy *winSystem, void* dpy,
+                         void* eglDisplay, bool &general, bool &hevc)
+{
+
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// ALSA
+//-----------------------------------------------------------------------------
+
+#ifdef HAS_ALSA
+#include "cores/AudioEngine/Sinks/AESinkALSA.h"
+bool GBM::ALSARegister()
+{
+  CAESinkALSA::Register();
+  return true;
+}
+#else
+bool GBM::ALSARegister()
+{
+  return false;
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// PulseAudio
+//-----------------------------------------------------------------------------
+
+#ifdef HAS_PULSEAUDIO
+#include "cores/AudioEngine/Sinks/AESinkPULSE.h"
+bool GBM::PulseAudioRegister()
+{
+  CAESinkPULSE::Register();
+  return true;
+}
+#else
+bool GBM::PulseAudioRegister()
+{
+  return false;
+}
+#endif

--- a/xbmc/windowing/gbm/OptionalsReg.cpp
+++ b/xbmc/windowing/gbm/OptionalsReg.cpp
@@ -32,6 +32,7 @@ class CVaapiProxy : public VAAPI::IVaapiWinSystem
 {
 public:
   CVaapiProxy() = default;
+  virtual ~CVaapiProxy() = default;
   VADisplay GetVADisplay() override;
   void *GetEGLDisplay() override { return eglDisplay; };
 

--- a/xbmc/windowing/gbm/OptionalsReg.h
+++ b/xbmc/windowing/gbm/OptionalsReg.h
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2005-2017 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+
+//-----------------------------------------------------------------------------
+// VAAPI
+//-----------------------------------------------------------------------------
+
+class CVaapiProxy;
+
+namespace GBM
+{
+CVaapiProxy* VaapiProxyCreate();
+void VaapiProxyDelete(CVaapiProxy *proxy);
+void VaapiProxyConfig(CVaapiProxy *proxy, void *eglDpy);
+void VAAPIRegister(CVaapiProxy *winSystem, bool hevc);
+void VAAPIRegisterRender(CVaapiProxy *winSystem, bool &general, bool &hevc);
+}
+
+//-----------------------------------------------------------------------------
+// ALSA
+//-----------------------------------------------------------------------------
+
+namespace GBM
+{
+bool ALSARegister();
+}
+
+//-----------------------------------------------------------------------------
+// PulseAudio
+//-----------------------------------------------------------------------------
+
+namespace GBM
+{
+bool PulseAudioRegister();
+}
+

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -18,23 +18,40 @@
  *
  */
 
-#if defined (HAVE_LIBVA)
-#include <va/va_drm.h>
-#endif
-
 #include "WinSystemGbm.h"
 
 #include <string.h>
 
+#include "OptionalsReg.h"
 #include "guilib/GraphicContext.h"
 #include "settings/DisplaySettings.h"
 #include "utils/log.h"
+#include "utils/StringUtils.h"
 #include "../WinEventsLinux.h"
 
 CWinSystemGbm::CWinSystemGbm() :
   m_nativeDisplay(nullptr),
   m_nativeWindow(nullptr)
 {
+  std::string envSink;
+  if (getenv("AE_SINK"))
+    envSink = getenv("AE_SINK");
+  if (StringUtils::CompareNoCase(envSink, "ALSA"))
+  {
+    GBM::ALSARegister();
+  }
+  else if (StringUtils::CompareNoCase(envSink, "PULSE"))
+  {
+   GBM::PulseAudioRegister();
+  }
+  else
+  {
+    if (!GBM::PulseAudioRegister())
+    {
+      GBM::ALSARegister();
+    }
+  }
+
   m_winEvents.reset(new CWinEventsLinux());
 }
 
@@ -157,36 +174,6 @@ void CWinSystemGbm::FlipPage(CGLContextEGL *pGLContext)
 void CWinSystemGbm::WaitVBlank()
 {
   CDRMUtils::WaitVBlank();
-}
-
-void* CWinSystemGbm::GetVaDisplay()
-{
-#if defined(HAVE_LIBVA)
-  int const buf_size{128};
-  char name[buf_size];
-  int fd{-1};
-
-  // 128 is the start of the NUM in renderD<NUM>
-  for (int i = 128; i < (128 + 16); i++)
-  {
-    snprintf(name, buf_size, "/dev/dri/renderD%u", i);
-
-    fd = open(name, O_RDWR);
-
-    if (fd < 0)
-    {
-      continue;
-    }
-
-    auto display = vaGetDisplayDRM(fd);
-
-    if (display != nullptr)
-    {
-      return display;
-    }
-  }
-#endif
-  return nullptr;
 }
 
 bool CWinSystemGbm::Hide()

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -53,8 +53,6 @@ public:
 
   void UpdateResolutions() override;
 
-  void* GetVaDisplay();
-
   bool Hide() override;
   bool Show(bool raise = true) override;
   virtual void Register(IDispResource *resource);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -28,6 +28,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 
 #include "WinSystemGbmGLESContext.h"
+#include "OptionalsReg.h"
 #include "utils/log.h"
 
 using namespace KODI;
@@ -37,26 +38,6 @@ std::unique_ptr<CWinSystemBase> CWinSystemBase::CreateWinSystem()
   std::unique_ptr<CWinSystemBase> winSystem(new CWinSystemGbmGLESContext());
   return winSystem;
 }
-
-#if defined (HAVE_LIBVA)
-#include <va/va_drm.h>
-#include "cores/VideoPlayer/DVDCodecs/Video/VAAPI.h"
-#include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h"
-
-class CVaapiProxy : public VAAPI::IVaapiWinSystem
-{
-public:
-  CVaapiProxy(CWinSystemGbmGLESContext &winSystem) : m_winSystem(winSystem) {};
-  VADisplay GetVADisplay() override { return m_winSystem.GetVaDisplay(); };
-  void *GetEGLDisplay() override { return m_winSystem.GetEGLDisplay(); };
-protected:
-  CWinSystemGbmGLESContext &m_winSystem;
-};
-#else
-class CVaapiProxy
-{
-};
-#endif
 
 bool CWinSystemGbmGLESContext::InitWindowSystem()
 {
@@ -76,16 +57,15 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
     return false;
   }
 
-#if defined (HAVE_LIBVA)
-  m_vaapiProxy.reset(new CVaapiProxy(*this));
-  VADisplay vaDpy = static_cast<VADisplay>(CWinSystemGbm::GetVaDisplay());
   bool general, hevc;
-  CRendererVAAPI::Register(m_vaapiProxy.get(), vaDpy, m_pGLContext.m_eglDisplay, general, hevc);
+  m_vaapiProxy.reset(GBM::VaapiProxyCreate());
+  GBM::VaapiProxyConfig(m_vaapiProxy.get(), m_pGLContext.m_eglDisplay);
+  GBM::VAAPIRegisterRender(m_vaapiProxy.get(), general, hevc);
+
   if (general)
   {
-    VAAPI::CDecoder::Register(m_vaapiProxy.get(), hevc);
+    GBM::VAAPIRegister(m_vaapiProxy.get(), hevc);
   }
-#endif
 
   CRendererDRMPRIME::Register();
   CDVDVideoCodecDRMPRIME::Register();
@@ -176,6 +156,11 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   {
     CWinSystemGbm::WaitVBlank();
   }
+}
+
+void CWinSystemGbmGLESContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) const
+{
+  GBM::VaapiProxyDelete(p);
 }
 
 EGLDisplay CWinSystemGbmGLESContext::GetEGLDisplay() const

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -51,5 +51,9 @@ protected:
 
 private:
   CGLContextEGL m_pGLContext;
-  std::unique_ptr<CVaapiProxy> m_vaapiProxy;
+  struct delete_CVaapiProxy
+  {
+    void operator()(CVaapiProxy *p) const;
+  };
+  std::unique_ptr<CVaapiProxy, delete_CVaapiProxy> m_vaapiProxy;
 };


### PR DESCRIPTION
Tested and working

I do get a warning during compilations though
```
[1439/1443] Building CXX object build/windowing/gbm/CMakeFiles/windowing_Gbm.dir/OptionalsReg.cpp.o
/home/lukas/libreelec/build.LibreELEC-Intel.x86_64-9.0-devel/kodi-1e9d6ba/xbmc/windowing/gbm/OptionalsReg.cpp: In function 'void GBM::VaapiProxyDelete(CVaapiProxy*)':
/home/lukas/libreelec/build.LibreELEC-Intel.x86_64-9.0-devel/kodi-1e9d6ba/xbmc/windowing/gbm/OptionalsReg.cpp:78:10: warning: deleting object of polymorphic class type 'CVaapiProxy' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
   delete proxy;
          ^~~~~
```