### PR TITLE
fixup! VideoPlayer: remove dead code - Renderer::Reset

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.cpp
@@ -890,11 +890,6 @@ void CMMALRenderer::ReleaseBuffer(int id)
   m_buffers[id] = nullptr;
 }
 
-void CMMALRenderer::Reset()
-{
-  CLog::Log(LOGDEBUG, "%s::%s", CLASSNAME, __func__);
-}
-
 void CMMALRenderer::Flush()
 {
   CSingleLock lock(m_sharedSection);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/MMALRenderer.h
@@ -152,7 +152,6 @@ public:
   virtual bool         Configure(const VideoPicture &picture, float fps, unsigned flags, unsigned int orientation) override;
   virtual void         ReleaseBuffer(int idx) override;
   virtual void         UnInit();
-  virtual void         Reset() override; /* resets renderer after seek for example */
   virtual void         Flush() override;
   virtual bool         IsConfigured() override { return m_bConfigured; }
   virtual void         AddVideoPicture(const VideoPicture& pic, int index, double currentClock) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererAML.h
@@ -44,7 +44,6 @@ public:
   virtual bool ConfigChanged(const VideoPicture &picture) { return false; };
   virtual CRenderInfo GetRenderInfo() override;
   virtual void UnInit() override {};
-  virtual void Reset() override;
   virtual void Update() override {};
   virtual void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   virtual bool SupportsMultiPassRendering()override { return false; };
@@ -57,6 +56,8 @@ public:
   virtual bool Supports(ERENDERFEATURE feature) override;
 
 private:
+  void Reset();
+
   static const int m_numRenderBuffers = 4;
 
   struct BUFFER

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -42,7 +42,6 @@ public:
   bool IsConfigured() override { return m_bConfigured; };
   void AddVideoPicture(const VideoPicture& picture, int index, double currentClock) override;
   void UnInit() override {};
-  void Reset() override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
   bool IsGuiLayer() override { return false; };
@@ -58,6 +57,7 @@ public:
   bool Supports(ESCALINGMETHOD method) override;
 
 private:
+  void Reset();
   void SetVideoPlane(CVideoBufferDRMPRIME* buffer);
 
   bool m_bConfigured = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -114,10 +114,6 @@ bool CRendererMediaCodecSurface::Supports(ERENDERFEATURE feature)
   return false;
 }
 
-void CRendererMediaCodecSurface::Reset()
-{
-}
-
 void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
   CXBMCApp::get()->WaitVSync(100);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -44,7 +44,6 @@ public:
   virtual bool ConfigChanged(const VideoPicture &picture) override { return false; };
   virtual CRenderInfo GetRenderInfo() override;
   virtual void UnInit() override {};
-  virtual void Reset() override;
   virtual void Update() override {};
   virtual void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   virtual bool SupportsMultiPassRendering() override { return false; };


### PR DESCRIPTION
feel free to squash my commits

kept Render as private method for AML and DRMPRIME as those call it in the destructor and I don't know if it is still needed