### PR TITLE
YUV2RGBShaderGL4: Extend to also support SPLINE36_FAST

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -795,6 +795,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
     return;
 
   case VS_SCALINGMETHOD_LANCZOS3_FAST:
+  case VS_SCALINGMETHOD_SPLINE36_FAST:
     {
       EShaderFormat fmt = GetShaderFormat();
       if (fmt == SHADER_NV12 || fmt == SHADER_YV12)
@@ -811,7 +812,6 @@ void CLinuxRendererGL::UpdateVideoFilter()
     }
 
   case VS_SCALINGMETHOD_LANCZOS2:
-  case VS_SCALINGMETHOD_SPLINE36_FAST:
   case VS_SCALINGMETHOD_SPLINE36:
   case VS_SCALINGMETHOD_LANCZOS3:
   case VS_SCALINGMETHOD_CUBIC:
@@ -904,11 +904,11 @@ void CLinuxRendererGL::LoadShaders(int field)
                            m_cmsOn ? m_tCLUTTex : 0,
                            m_CLUTsize);
 
-      if (m_scalingMethod == VS_SCALINGMETHOD_LANCZOS3_FAST)
+      if (m_scalingMethod == VS_SCALINGMETHOD_LANCZOS3_FAST || m_scalingMethod == VS_SCALINGMETHOD_SPLINE36_FAST)
       {
         m_pYUVShader = new YUV2RGBFilterShader4(m_textureTarget == GL_TEXTURE_RECTANGLE_ARB,
                                                 m_iFlags, shaderFormat, m_nonLinStretch,
-                                                out);
+                                                m_scalingMethod, out);
         if (!m_cmsOn)
           m_pYUVShader->SetConvertFullColorRange(m_fullRange);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -198,9 +198,11 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(bool rect, unsigned flags, ES
 YUV2RGBFilterShader4::YUV2RGBFilterShader4(bool rect, unsigned flags,
                                            EShaderFormat format,
                                            bool stretch,
+                                           ESCALINGMETHOD method,
                                            GLSLOutput *output)
 : BaseYUV2RGBGLSLShader(rect, flags, format, stretch, output)
 {
+  m_scaling = method;
   PixelShader()->LoadSource("gl_yuv2rgb_filter4.glsl", m_defines);
   PixelShader()->AppendSource("gl_output.glsl");
 }
@@ -217,7 +219,13 @@ void YUV2RGBFilterShader4::OnCompiledAndLinked()
   BaseYUV2RGBGLSLShader::OnCompiledAndLinked();
   m_hKernTex = glGetUniformLocation(ProgramHandle(), "m_kernelTex");
 
-  CConvolutionKernel kernel(VS_SCALINGMETHOD_LANCZOS3_FAST, 256);
+  if (m_scaling != VS_SCALINGMETHOD_LANCZOS3_FAST || m_scaling != VS_SCALINGMETHOD_SPLINE36_FAST)
+  {
+    CLog::Log(LOGERROR, "GL: BaseYUV2RGBGLSLShader4 - unsupported scaling %d will fallback", m_scaling);
+    m_scaling = VS_SCALINGMETHOD_LANCZOS3_FAST;
+  }
+
+  CConvolutionKernel kernel(m_scaling, 256);
 
   if (m_kernelTex)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -23,6 +23,7 @@
 #include "ShaderFormats.h"
 #include "GLSLOutput.h"
 #include "guilib/Shader.h"
+#include "cores/VideoSettings.h"
 
 void CalculateYUVMatrix(TransformMatrix &matrix
                         , unsigned int  flags
@@ -118,6 +119,7 @@ public:
                        unsigned flags,
                        EShaderFormat format,
                        bool stretch,
+                       ESCALINGMETHOD method,
                        GLSLOutput *output);
   ~YUV2RGBFilterShader4() override;
 
@@ -127,6 +129,7 @@ protected:
 
   GLuint m_kernelTex = 0;
   GLint m_hKernTex = -1;
+  ESCALINGMETHOD m_scaling = VS_SCALINGMETHOD_LANCZOS3_FAST;
 };
 
 } // end namespace


### PR DESCRIPTION
This also adds our other 4x4 filter to the new code path.