### PR TITLE
RendererVAAPI: Adjust for m_srcTextureBits moved to buffer

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -186,7 +186,7 @@ bool CRendererVAAPI::UploadTexture(int index)
   }
 
   m_vaapiTextures[index].Map(pic);
-  m_srcTextureBits = m_vaapiTextures[index].GetBits();
+  m_buffers[index].m_srcTextureBits = m_vaapiTextures[index].GetBits();
 
   YuvImage &im = buf.image;
   YUVPLANE (&planes)[3] = buf.fields[0];


### PR DESCRIPTION
As discussed on slack. 

Btw. from encapsulation pov - a setter on the buffer would be more appropriate. Can be done later obviously.