### PR TITLE
fixup! display resolutions: drop iScreen

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -718,7 +718,7 @@ void CDisplaySettings::SettingOptionsRefreshRatesFiller(SettingConstPtr setting,
   }
 
   RESOLUTION_INFO resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(res);
-  // The only meaningful parts of res here are iScreen, iScreenWidth, iScreenHeight
+  // The only meaningful parts of res here are iScreenWidth, iScreenHeight
   std::vector<REFRESHRATE> refreshrates = CServiceBroker::GetWinSystem()->RefreshRates(resInfo.iScreenWidth, resInfo.iScreenHeight, resInfo.dwFlags);
 
   bool match = false;

--- a/xbmc/utils/AMLUtils.cpp
+++ b/xbmc/utils/AMLUtils.cpp
@@ -455,7 +455,6 @@ bool aml_mode_to_resolution(const char *mode, RESOLUTION_INFO *res)
     }
   }
 
-  res->iScreen       = 0;
   res->bFullScreen   = true;
   res->iSubtitles    = (int)(0.965 * res->iHeight);
   res->fPixelRatio   = 1.0f;

--- a/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
+++ b/xbmc/windowing/amlogic/WinSystemAmlogic.cpp
@@ -219,10 +219,9 @@ void CWinSystemAmlogic::UpdateResolutions()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
     CDisplaySettings::GetInstance().GetResolutionInfo(res_index) = resolutions[i];
 
-    CLog::Log(LOGNOTICE, "Found resolution %d x %d for display %d with %d x %d%s @ %f Hz\n",
+    CLog::Log(LOGNOTICE, "Found resolution %d x %d with %d x %d%s @ %f Hz\n",
       resolutions[i].iWidth,
       resolutions[i].iHeight,
-      resolutions[i].iScreen,
       resolutions[i].iScreenWidth,
       resolutions[i].iScreenHeight,
       resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -99,7 +99,6 @@ static void fetchDisplayModes()
         s_res_cur_displayMode.iHeight = s_res_cur_displayMode.iScreenHeight = m.getPhysicalHeight();
         s_res_cur_displayMode.fRefreshRate = m.getRefreshRate();
         s_res_cur_displayMode.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-        s_res_cur_displayMode.iScreen       = 0;
         s_res_cur_displayMode.bFullScreen   = true;
         s_res_cur_displayMode.iSubtitles    = (int)(0.965 * s_res_cur_displayMode.iHeight);
         s_res_cur_displayMode.fPixelRatio   = 1.0f;
@@ -117,7 +116,6 @@ static void fetchDisplayModes()
           res.iHeight = res.iScreenHeight = m.getPhysicalHeight();
           res.fRefreshRate = m.getRefreshRate();
           res.dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-          res.iScreen       = 0;
           res.bFullScreen   = true;
           res.iSubtitles    = (int)(0.965 * res.iHeight);
           res.fPixelRatio   = 1.0f;
@@ -226,7 +224,6 @@ bool CAndroidUtils::GetNativeResolution(RESOLUTION_INFO *res) const
     res->strId = "-1";
     res->fRefreshRate = currentRefreshRate();
     res->dwFlags= D3DPRESENTFLAG_PROGRESSIVE;
-    res->iScreen       = 0;
     res->bFullScreen   = true;
     res->iWidth = m_width;
     res->iHeight = m_height;

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -204,10 +204,9 @@ void CWinSystemAndroid::UpdateResolutions()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
     CDisplaySettings::GetInstance().GetResolutionInfo(res_index) = resolutions[i];
 
-    CLog::Log(LOGNOTICE, "Found resolution %d x %d for display %d with %d x %d%s @ %f Hz\n",
+    CLog::Log(LOGNOTICE, "Found resolution %d x %d with %d x %d%s @ %f Hz\n",
       resolutions[i].iWidth,
       resolutions[i].iHeight,
-      resolutions[i].iScreen,
       resolutions[i].iScreenWidth,
       resolutions[i].iScreenHeight,
       resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",

--- a/xbmc/windowing/gbm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/DRMUtils.cpp
@@ -608,7 +608,6 @@ void CDRMUtils::DestroyDrm()
 RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
 {
   RESOLUTION_INFO res;
-  res.iScreen = 0;
   res.iScreenWidth = mode->hdisplay;
   res.iScreenHeight = mode->vdisplay;
   res.iWidth = res.iScreenWidth;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -182,10 +182,9 @@ void CWinSystemGbm::UpdateResolutions()
         CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP) = res;
       }
 
-      CLog::Log(LOGNOTICE, "Found resolution %dx%d for display %d with %dx%d%s @ %f Hz",
+      CLog::Log(LOGNOTICE, "Found resolution %dx%d with %dx%d%s @ %f Hz",
                 res.iWidth,
                 res.iHeight,
-                res.iScreen,
                 res.iScreenWidth,
                 res.iScreenHeight,
                 res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",

--- a/xbmc/windowing/osx/WinSystemIOS.mm
+++ b/xbmc/windowing/osx/WinSystemIOS.mm
@@ -192,7 +192,7 @@ bool CWinSystemIOS::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   m_nHeight     = res.iHeight;
   m_bFullScreen = fullScreen;
 
-  CLog::Log(LOGDEBUG, "About to switch to %i x %i on screen %i",m_nWidth, m_nHeight, res.iScreen);
+  CLog::Log(LOGDEBUG, "About to switch to %i x %i",m_nWidth, m_nHeight);
   SwitchToVideoMode(res.iWidth, res.iHeight, res.fRefreshRate);
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight);
 

--- a/xbmc/windowing/rpi/RPIUtils.cpp
+++ b/xbmc/windowing/rpi/RPIUtils.cpp
@@ -396,7 +396,6 @@ bool CRPIUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
 
     if ((tv_state.state & ( VC_HDMI_HDMI | VC_HDMI_DVI )) != 0) // hdtv
     {
-      m_desktopRes.iScreen      = 0;
       m_desktopRes.bFullScreen  = true;
       m_desktopRes.iWidth       = tv_state.display.hdmi.width;
       m_desktopRes.iHeight      = tv_state.display.hdmi.height;
@@ -411,7 +410,6 @@ bool CRPIUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
     }
     else if ((tv_state.state & ( VC_SDTV_NTSC | VC_SDTV_PAL )) != 0) // sdtv
     {
-      m_desktopRes.iScreen      = 0;
       m_desktopRes.bFullScreen  = true;
       m_desktopRes.iWidth       = tv_state.display.sdtv.width;
       m_desktopRes.iHeight      = tv_state.display.sdtv.height;
@@ -423,7 +421,6 @@ bool CRPIUtils::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutions)
     }
     else if ((tv_state.state & VC_LCD_ATTACHED_DEFAULT) != 0) // lcd
     {
-      m_desktopRes.iScreen      = 0;
       m_desktopRes.bFullScreen  = true;
       m_desktopRes.iWidth       = tv_state.display.sdtv.width;
       m_desktopRes.iHeight      = tv_state.display.sdtv.height;
@@ -543,7 +540,6 @@ void CRPIUtils::GetSupportedModes(HDMI_RES_GROUP_T group, std::vector<RESOLUTION
     {
       RESOLUTION_INFO res;
 
-      res.iScreen       = 0;
       res.bFullScreen   = true;
       res.dwFlags       = MAKEFLAGS(group, tv->code, tv->scan_mode);
       res.fRefreshRate  = (float)tv->frame_rate;

--- a/xbmc/windowing/rpi/WinSystemRpi.cpp
+++ b/xbmc/windowing/rpi/WinSystemRpi.cpp
@@ -187,10 +187,9 @@ void CWinSystemRpi::UpdateResolutions()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(resolutions[i]);
     CDisplaySettings::GetInstance().GetResolutionInfo(res_index) = resolutions[i];
 
-    CLog::Log(LOGNOTICE, "Found resolution %d x %d for display %d with %d x %d%s @ %f Hz\n",
+    CLog::Log(LOGNOTICE, "Found resolution %d x %d with %d x %d%s @ %f Hz\n",
       resolutions[i].iWidth,
       resolutions[i].iHeight,
-      resolutions[i].iScreen,
       resolutions[i].iScreenWidth,
       resolutions[i].iScreenHeight,
       resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -424,23 +424,6 @@ bool CWinSystemWayland::CanDoWindowed()
   return true;
 }
 
-int CWinSystemWayland::GetNumScreens()
-{
-  // Multiple screen/resolution support in core Kodi badly needs refactoring, but as
-  // it touches a lot of code we just do it like X11 for the moment:
-  // Pretend that there is only one screen, show more screens with
-  // custom names in the GUI using an #ifdef in DisplaySettings
-  // - otherwise we would just get a selection between "Full Screen #1" and
-  // "Full Screen #2" etc. instead of actual monitor names.
-  return 1;
-}
-
-int CWinSystemWayland::GetCurrentScreen()
-{
-  // See GetNumScreens()
-  return 1;
-}
-
 void CWinSystemWayland::GetConnectedOutputs(std::vector<std::string>* outputs)
 {
   CSingleLock lock(m_outputsMutex);

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -79,8 +79,6 @@ public:
   bool UseLimitedColor() override;
 
   void UpdateResolutions() override;
-  int GetNumScreens() override;
-  int GetCurrentScreen() override;
 
   bool CanDoWindowed() override;
   bool Minimize() override;

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -118,7 +118,6 @@ bool CWinSystemWin10::CreateNewWindow(const std::string& name, bool fullScreen, 
   m_nWidth = res.iWidth;
   m_nHeight = res.iHeight;
   m_bFullScreen = fullScreen;
-  m_nScreen = res.iScreen;
   m_fRefreshRate = res.fRefreshRate;
   m_inFocus = true;
   m_bWindowCreated = true;
@@ -313,13 +312,6 @@ const MONITOR_DETAILS* CWinSystemWin10::GetDefaultMonitor() const
   return &m_displays.front();
 }
 
-int CWinSystemWin10::GetCurrentScreen()
-{
-  CLog::Log(LOGDEBUG, "%s is not implemented", __FUNCTION__);
-  // fallback to default
-  return 0;
-}
-
 bool CWinSystemWin10::ChangeResolution(const RESOLUTION_INFO& res, bool forceChange /*= false*/)
 {
   const MONITOR_DETAILS* details = GetDefaultMonitor();
@@ -402,7 +394,7 @@ void CWinSystemWin10::UpdateResolutions()
     refreshRate = static_cast<float>(details->RefreshRate);
 
   RESOLUTION_INFO& primary_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-  UpdateDesktopResolution(primary_info, 0, w, h, refreshRate, dwFlags);
+  UpdateDesktopResolution(primary_info, w, h, refreshRate, dwFlags);
   CLog::Log(LOGNOTICE, "Primary mode: %s", primary_info.strMode.c_str());
 
   // erase previous stored modes
@@ -417,7 +409,7 @@ void CWinSystemWin10::UpdateResolutions()
       for (auto& mode : hdmiModes)
       {
         RESOLUTION_INFO res;
-        UpdateDesktopResolution(res, 0, mode.ResolutionWidthInRawPixels(), mode.ResolutionHeightInRawPixels(), mode.RefreshRate(), 0);
+        UpdateDesktopResolution(res, mode.ResolutionWidthInRawPixels(), mode.ResolutionHeightInRawPixels(), mode.RefreshRate(), 0);
         GetGfxContext().ResetOverscan(res);
 
         if (AddResolution(res))

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -85,8 +85,6 @@ public:
   void FinishWindowResize(int newWidth, int newHeight) override;
   void UpdateResolutions() override;
   void NotifyAppFocusChange(bool bGaining) override;
-  int  GetNumScreens() override { return m_displays.size(); };
-  int  GetCurrentScreen() override;
   void ShowOSMouse(bool show) override;
   bool HasInertialGestures() override { return true; }//if win32 has touchscreen - it uses the win32 gesture api for inertial scrolling
   bool Minimize() override;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -888,7 +888,7 @@ void CWinSystemWin32::UpdateResolutions()
   uint32_t dwFlags = details->Interlaced ? D3DPRESENTFLAG_INTERLACED : 0;
 
   RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-  UpdateDesktopResolution(info, 0, w, h, refreshRate, dwFlags);
+  UpdateDesktopResolution(info, w, h, refreshRate, dwFlags);
   info.strOutput = strOuput;
 
   CLog::Log(LOGNOTICE, "Primary mode: %s", info.strMode.c_str());
@@ -913,7 +913,7 @@ void CWinSystemWin32::UpdateResolutions()
     dwFlags = (devmode.dmDisplayFlags & DM_INTERLACED) ? D3DPRESENTFLAG_INTERLACED : 0;
 
     RESOLUTION_INFO res;
-    UpdateDesktopResolution(res, 0, devmode.dmPelsWidth, devmode.dmPelsHeight, refresh, dwFlags);
+    UpdateDesktopResolution(res, devmode.dmPelsWidth, devmode.dmPelsHeight, refresh, dwFlags);
     GetGfxContext().ResetOverscan(res);
     res.strOutput = strOuput;
 


### PR DESCRIPTION
compile tested for windows (desktop and uwp)

1. commit remove iScreen = 0
2. fix windows
3. remove iScreen logging
4. remove unused wayland functions

If you want I can remove the 3rd commit, don't know if platform maintainers want to log something different.